### PR TITLE
33 opinions create opinion

### DIFF
--- a/backend/build-logic/src/main/kotlin/com/r8n/backend/buildlogic/NonreactiveBackendServiceConventionPlugin.kt
+++ b/backend/build-logic/src/main/kotlin/com/r8n/backend/buildlogic/NonreactiveBackendServiceConventionPlugin.kt
@@ -19,6 +19,7 @@ class NonreactiveBackendServiceConventionPlugin : Plugin<Project> {
 
             dependencies.apply {
                 add("implementation", project(":core:security"))
+                add("implementation", libs.findLibrary("spring-boot-starter-oauth").get())
                 add("implementation", libs.findLibrary("spring-boot-starter-web").get())
                 add("implementation", libs.findLibrary("spring-swagger").get())
                 add("testImplementation", libs.findLibrary("spring-boot-starter-webmvc-test").get())

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/OpinionApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/OpinionApi.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
 interface OpinionApi {
@@ -21,9 +22,13 @@ interface OpinionApi {
 
     @PostMapping("/opinions")
     fun createOpinion(
+        @RequestParam(required = true)
         subjectId: UUID,
+        @RequestParam(required = false)
         subjective: List<String>,
+        @RequestParam(required = false)
         objective: List<String>,
+        @RequestParam(required = false)
         mark: Double?,
     ): OpinionDto
 

--- a/backend/opinions-sv/service/build.gradle.kts
+++ b/backend/opinions-sv/service/build.gradle.kts
@@ -12,6 +12,5 @@ dependencies {
     implementation(project(":users-api-integration"))
     implementation(project(":users-client"))
     implementation(project(":mock-sv"))
-    implementation(libs.spring.boot.starter.oauth)
     testImplementation(project(":mock-api"))
 }

--- a/backend/opinions-sv/service/build.gradle.kts
+++ b/backend/opinions-sv/service/build.gradle.kts
@@ -12,5 +12,6 @@ dependencies {
     implementation(project(":users-api-integration"))
     implementation(project(":users-client"))
     implementation(project(":mock-sv"))
+    implementation(libs.spring.boot.starter.oauth)
     testImplementation(project(":mock-api"))
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
@@ -4,6 +4,7 @@ import com.r8n.backend.mock.stub.OpinionTestDataFactory
 import com.r8n.backend.opinions.api.OpinionApi
 import com.r8n.backend.opinions.api.dto.OpinionDto
 import com.r8n.backend.opinions.facade.OpinionFacade
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -16,16 +17,15 @@ class OpinionController(
     override fun getOpinionFor(subjectId: UUID) = opinionFacade.getOpinionFor(subjectId)
 
     override fun createOpinion(
+        @RequestParam(required = true)
         subjectId: UUID,
+        @RequestParam(required = false)
         subjective: List<String>,
+        @RequestParam(required = false)
         objective: List<String>,
+        @RequestParam(required = false)
         mark: Double?,
-    ) = OpinionTestDataFactory.postOpinion(
-        subjectId = subjectId,
-        subjective = subjective,
-        objective = objective,
-        mark = mark,
-    )
+    ) = opinionFacade.createOpinionDto(subjectId, subjective, objective, mark)
 
     override fun updateOpinion(
         opinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
@@ -4,7 +4,7 @@ import com.r8n.backend.mock.stub.OpinionTestDataFactory
 import com.r8n.backend.opinions.api.OpinionApi
 import com.r8n.backend.opinions.api.dto.OpinionDto
 import com.r8n.backend.opinions.facade.OpinionFacade
-import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
@@ -17,15 +17,15 @@ class OpinionController(
     override fun getOpinionFor(subjectId: UUID) = opinionFacade.getOpinionFor(subjectId)
 
     override fun createOpinion(
-        @RequestParam(required = true)
         subjectId: UUID,
-        @RequestParam(required = false)
         subjective: List<String>,
-        @RequestParam(required = false)
         objective: List<String>,
-        @RequestParam(required = false)
         mark: Double?,
-    ) = opinionFacade.createOpinionDto(subjectId, subjective, objective, mark)
+    ): OpinionDto {
+        val auth = SecurityContextHolder.getContext().authentication ?: throw IllegalStateException("Not authenticated")
+        val userId = UUID.fromString(auth.name)
+        return opinionFacade.createOpinionDto(userId, subjectId, subjective, objective, mark)
+    }
 
     override fun updateOpinion(
         opinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
@@ -24,7 +24,7 @@ class OpinionController(
     ): OpinionDto {
         val auth = SecurityContextHolder.getContext().authentication ?: throw IllegalStateException("Not authenticated")
         val userId = UUID.fromString(auth.name)
-        return opinionFacade.createOpinionDto(userId, subjectId, subjective, objective, mark)
+        return opinionFacade.createOpinion(userId, subjectId, subjective, objective, mark)
     }
 
     override fun updateOpinion(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
@@ -17,6 +17,13 @@ class OpinionFacade(
 
     fun getOpinionFor(subjectId: UUID): OpinionDto = opinionService.getOpinionFor(subjectId).toDto()
 
+    fun createOpinionDto(
+        subjectId: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+        mark: Double?,
+    ): OpinionDto = opinionService.createOpinion(subjectId, subjective, objective, mark).toDto()
+
     private fun Opinion.toDto() =
         OpinionDto(
             id,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
@@ -17,7 +17,7 @@ class OpinionFacade(
 
     fun getOpinionFor(subjectId: UUID): OpinionDto = opinionService.getOpinionFor(subjectId).toDto()
 
-    fun createOpinionDto(
+    fun createOpinion(
         userId: UUID,
         subjectId: UUID,
         subjective: List<String>,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
@@ -18,11 +18,12 @@ class OpinionFacade(
     fun getOpinionFor(subjectId: UUID): OpinionDto = opinionService.getOpinionFor(subjectId).toDto()
 
     fun createOpinionDto(
+        userId: UUID,
         subjectId: UUID,
         subjective: List<String>,
         objective: List<String>,
         mark: Double?,
-    ): OpinionDto = opinionService.createOpinion(subjectId, subjective, objective, mark).toDto()
+    ): OpinionDto = opinionService.createOpinion(userId, subjectId, subjective, objective, mark).toDto()
 
     private fun Opinion.toDto() =
         OpinionDto(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/persistence/OpinionNotePersistence.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/persistence/OpinionNotePersistence.kt
@@ -17,11 +17,14 @@ class OpinionNotePersistence(
     @GeneratedValue
     @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
     val id: UUID? = null,
+//
     @Column(nullable = false)
     val opinionId: UUID,
+//
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     val type: OpinionNoteTypeEnum,
+//
     @Column(nullable = false)
     val description: String,
 )

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/persistence/OpinionNotePersistence.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/persistence/OpinionNotePersistence.kt
@@ -16,15 +16,12 @@ class OpinionNotePersistence(
     @Id
     @GeneratedValue
     @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
-    val id: UUID,
-//
+    val id: UUID? = null,
     @Column(nullable = false)
     val opinionId: UUID,
-//
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     val type: OpinionNoteTypeEnum,
-//
     @Column(nullable = false)
     val description: String,
 )

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionNoteService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionNoteService.kt
@@ -1,5 +1,6 @@
 package com.r8n.backend.opinions.service
 
+import com.r8n.backend.opinions.persistence.OpinionNotePersistence
 import com.r8n.backend.opinions.persistence.OpinionNoteTypeEnum
 import com.r8n.backend.opinions.provider.database.OpinionNoteRepository
 import org.springframework.stereotype.Service
@@ -18,4 +19,21 @@ class OpinionNoteService(
         opinionNoteRepository
             .findAllByOpinionIdAndTypeOrderByIdAsc(id, OpinionNoteTypeEnum.OBJECTIVE)
             .map { it.description }
+
+    fun create(
+        id: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+    ) {
+        val notes =
+            buildList {
+                subjective.forEach {
+                    add(OpinionNotePersistence(opinionId = id, type = OpinionNoteTypeEnum.SUBJECTIVE, description = it))
+                }
+                objective.forEach {
+                    add(OpinionNotePersistence(opinionId = id, type = OpinionNoteTypeEnum.OBJECTIVE, description = it))
+                }
+            }
+        opinionNoteRepository.saveAll(notes)
+    }
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
@@ -32,6 +32,7 @@ class OpinionService(
 
     @Transactional
     fun createOpinion(
+        ownerId: UUID,
         subjectId: UUID,
         subjective: List<String>,
         objective: List<String>,
@@ -40,7 +41,7 @@ class OpinionService(
         val opinion =
             opinionRepository.save(
                 OpinionPersistence(
-                    owner = STUB_OWNER_ID,
+                    owner = ownerId,
                     subject = subjectId,
                     mark = mark,
                     status = OpinionStatusEnum.DRAFT,
@@ -64,8 +65,4 @@ class OpinionService(
             opinion.status,
             opinion.timestamp,
         )
-
-    private companion object {
-        val STUB_OWNER_ID: UUID = UUID.fromString("10101010-1010-1010-1010-101010101010")
-    }
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
@@ -1,11 +1,14 @@
 package com.r8n.backend.opinions.service
 
 import com.r8n.backend.opinions.domain.Opinion
+import com.r8n.backend.opinions.domain.OpinionStatusEnum
 import com.r8n.backend.opinions.persistence.OpinionPersistence
 import com.r8n.backend.opinions.provider.database.OpinionRepository
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
+import java.time.Instant
 import java.util.UUID
 
 @Service
@@ -27,6 +30,27 @@ class OpinionService(
         return toDomain(opinion)
     }
 
+    @Transactional
+    fun createOpinion(
+        subjectId: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+        mark: Double?,
+    ): Opinion {
+        val opinion =
+            opinionRepository.save(
+                OpinionPersistence(
+                    owner = STUB_OWNER_ID,
+                    subject = subjectId,
+                    mark = mark,
+                    status = OpinionStatusEnum.DRAFT,
+                    timestamp = Instant.now(),
+                ),
+            )
+        noteService.create(opinion.id!!, subjective, objective)
+        return toDomain(opinion)
+    }
+
     private fun toDomain(opinion: OpinionPersistence): Opinion =
         Opinion(
             opinion.id!!,
@@ -40,4 +64,8 @@ class OpinionService(
             opinion.status,
             opinion.timestamp,
         )
+
+    private companion object {
+        val STUB_OWNER_ID: UUID = UUID.fromString("10101010-1010-1010-1010-101010101010")
+    }
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
@@ -20,14 +20,14 @@ class OpinionService(
 ) {
     fun getOpinion(id: UUID): Opinion {
         val opinion = opinionRepository.findById(id).orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND) }
-        return toDomain(opinion)
+        return opinion.toDomain()
     }
 
     fun getOpinionFor(subjectId: UUID): Opinion {
         val opinion =
             opinionRepository.findFirstBySubjectOrderByTimestampDesc(subjectId)
                 ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
-        return toDomain(opinion)
+        return opinion.toDomain()
     }
 
     @Transactional
@@ -49,20 +49,20 @@ class OpinionService(
                 ),
             )
         noteService.create(opinion.id!!, subjective, objective)
-        return toDomain(opinion)
+        return opinion.toDomain()
     }
 
-    private fun toDomain(opinion: OpinionPersistence): Opinion =
+    private fun OpinionPersistence.toDomain(): Opinion =
         Opinion(
-            opinion.id!!,
-            opinion.owner,
-            opinion.subject,
-            subjectService.getSubjectName(opinion.subject),
-            noteService.getSubjective(opinion.id!!),
-            noteService.getObjective(opinion.id!!),
-            opinion.mark,
-            componentService.getComponentSection(opinion.id!!),
-            opinion.status,
-            opinion.timestamp,
+            id!!,
+            owner,
+            subject,
+            subjectService.getSubjectName(subject),
+            noteService.getSubjective(id!!),
+            noteService.getObjective(id!!),
+            mark,
+            componentService.getComponentSection(id!!),
+            status,
+            timestamp,
         )
 }

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -43,6 +43,9 @@ import java.util.UUID
 @Import(TestObjectMapperConfiguration::class)
 class OpinionsIntegrationTests {
     private companion object {
+        val CURRENT_USER_ID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+        const val CURRENT_USER_NAME = "username"
+
         @Container
         @ServiceConnection
         val postgres: PostgreSQLContainer =
@@ -66,6 +69,8 @@ class OpinionsIntegrationTests {
     fun setUp() {
         whenever(usersInternalApi.getUserName(eq(bernardReferent.id)))
             .thenReturn(bernardReferent.name)
+        whenever(usersInternalApi.getUserName(eq(CURRENT_USER_ID)))
+            .thenReturn(CURRENT_USER_NAME)
     }
 
     @Test
@@ -148,8 +153,8 @@ class OpinionsIntegrationTests {
                 .andReturn()
 
         val actual: OpinionDto = objectMapper.readValue(result.response.contentAsString)
-        assertEquals(UUID.fromString("10101010-1010-1010-1010-101010101010"), actual.owner)
-        assertEquals(bernardReferent.name, actual.ownerName)
+        assertEquals(CURRENT_USER_ID, actual.owner)
+        assertEquals(CURRENT_USER_NAME, actual.ownerName)
         assertEquals(UUID.fromString(subjectId), actual.subject)
         assertEquals(cappuccino1G.name, actual.subjectName)
         assertEquals(listOf("new subjective"), actual.subjective)

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -2,6 +2,7 @@ package com.r8n.backend.opinions
 
 import com.r8n.backend.mock.stub.OpinionSubjectTestDataFactory.bernardReferent
 import com.r8n.backend.mock.stub.OpinionSubjectTestDataFactory.cappuccino1A
+import com.r8n.backend.mock.stub.OpinionSubjectTestDataFactory.cappuccino1G
 import com.r8n.backend.opinions.api.dto.OpinionDto
 import com.r8n.backend.opinions.api.dto.OpinionStatusEnumDto
 import com.r8n.backend.users.integration.api.UsersInternalApi
@@ -21,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
@@ -127,5 +129,32 @@ class OpinionsIntegrationTests {
                 Instant.parse("2024-02-01T09:30:00Z"),
             )
         assertEquals(expected, actual)
+    }
+
+    @Test
+    @WithMockUser
+    fun `create opinion works`() {
+        val subjectId = "15151515-1515-1515-1515-151515151515"
+        val result =
+            mockMvc
+                .perform(
+                    post("/opinions")
+                        .queryParam("subjectId", subjectId)
+                        .queryParam("subjective", "new subjective")
+                        .queryParam("objective", "new objective")
+                        .queryParam("mark", "4.50")
+                        .header("Authorization", "Bearer stub-access-token-123"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: OpinionDto = objectMapper.readValue(result.response.contentAsString)
+        assertEquals(UUID.fromString("10101010-1010-1010-1010-101010101010"), actual.owner)
+        assertEquals(bernardReferent.name, actual.ownerName)
+        assertEquals(UUID.fromString(subjectId), actual.subject)
+        assertEquals(cappuccino1G.name, actual.subjectName)
+        assertEquals(listOf("new subjective"), actual.subjective)
+        assertEquals(listOf("new objective"), actual.objective)
+        assertEquals(4.5, actual.mark)
+        assertEquals(OpinionStatusEnumDto.DRAFT, actual.status)
     }
 }

--- a/backend/users-sv/service/build.gradle.kts
+++ b/backend/users-sv/service/build.gradle.kts
@@ -14,5 +14,4 @@ dependencies {
     implementation(project(":mock-api-integration"))
     implementation(project(":mock-client"))
     implementation(project(":mock-sv"))
-    implementation(libs.spring.boot.starter.oauth)
 }


### PR DESCRIPTION
Target changes:

- implemented opinions-sv endpoint `POST /opinions` as DB-backed flow
- replaced stub response in controller (`OpinionTestDataFactory.postOpinion`) with facade call
- added `OpinionFacade.createOpinion(subjectId, subjective, objective, mark)`
- added `OpinionService.createOpinion(...)` with transactional persistence
- persisted created opinion notes via `OpinionNoteService.create(...)` (`SUBJECTIVE` and `OBJECTIVE`)
- adjusted `OpinionNotePersistence` id handling to use Hibernate-generated UUIDs (fixing persistence error on create)
- added integration test for create-opinion path (`create opinion works()`)

Verification:

- `make docker-run-database`
- `make test-github` -> BUILD SUCCESSFUL