### PR TITLE
34 opinions update opinion

### DIFF
--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/OpinionApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/OpinionApi.kt
@@ -35,8 +35,11 @@ interface OpinionApi {
     @PatchMapping("/opinions/{opinionId}")
     fun updateOpinion(
         @PathVariable opinionId: UUID,
+        @RequestParam(required = false)
         subjective: List<String>,
+        @RequestParam(required = false)
         objective: List<String>,
+        @RequestParam(required = false)
         mark: Double?,
     ): OpinionDto
 

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/controller/OpinionController.kt
@@ -32,12 +32,7 @@ class OpinionController(
         subjective: List<String>,
         objective: List<String>,
         mark: Double?,
-    ) = OpinionTestDataFactory.postOpinion(
-        opinionId = opinionId,
-        subjective = subjective,
-        objective = objective,
-        mark = mark,
-    )
+    ) = opinionFacade.updateOpinion(opinionId, subjective, objective, mark)
 
     override fun deleteOpinion(opinionId: UUID) {
     }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/facade/OpinionFacade.kt
@@ -25,6 +25,13 @@ class OpinionFacade(
         mark: Double?,
     ): OpinionDto = opinionService.createOpinion(userId, subjectId, subjective, objective, mark).toDto()
 
+    fun updateOpinion(
+        opinionId: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+        mark: Double?,
+    ): OpinionDto = opinionService.updateOpinion(opinionId, subjective, objective, mark).toDto()
+
     private fun Opinion.toDto() =
         OpinionDto(
             id,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/provider/database/OpinionNoteRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/provider/database/OpinionNoteRepository.kt
@@ -10,4 +10,6 @@ interface OpinionNoteRepository : JpaRepository<OpinionNotePersistence, UUID> {
         opinionId: UUID,
         type: OpinionNoteTypeEnum,
     ): List<OpinionNotePersistence>
+
+    fun deleteAllByOpinionId(opinionId: UUID)
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionNoteService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionNoteService.kt
@@ -36,4 +36,13 @@ class OpinionNoteService(
             }
         opinionNoteRepository.saveAll(notes)
     }
+
+    fun replace(
+        id: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+    ) {
+        opinionNoteRepository.deleteAllByOpinionId(id)
+        create(id, subjective, objective)
+    }
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/service/OpinionService.kt
@@ -52,6 +52,25 @@ class OpinionService(
         return opinion.toDomain()
     }
 
+    @Transactional
+    fun updateOpinion(
+        opinionId: UUID,
+        subjective: List<String>,
+        objective: List<String>,
+        mark: Double?,
+    ): Opinion {
+        val opinion =
+            opinionRepository
+                .findById(
+                    opinionId,
+                ).orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND) }
+        opinion.mark = mark
+        opinion.timestamp = Instant.now()
+        val savedOpinion = opinionRepository.save(opinion)
+        noteService.replace(savedOpinion.id!!, subjective, objective)
+        return savedOpinion.toDomain()
+    }
+
     private fun OpinionPersistence.toDomain(): Opinion =
         Opinion(
             id!!,

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -22,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.testcontainers.junit.jupiter.Container
@@ -160,6 +161,46 @@ class OpinionsIntegrationTests {
         assertEquals(listOf("new subjective"), actual.subjective)
         assertEquals(listOf("new objective"), actual.objective)
         assertEquals(4.5, actual.mark)
+        assertEquals(OpinionStatusEnumDto.DRAFT, actual.status)
+    }
+
+    @Test
+    @WithMockUser
+    fun `update opinion works`() {
+        val createResult =
+            mockMvc
+                .perform(
+                    post("/opinions")
+                        .queryParam("subjectId", "15151515-1515-1515-1515-151515151515")
+                        .queryParam("subjective", "to be replaced subjective")
+                        .queryParam("objective", "to be replaced objective")
+                        .queryParam("mark", "2.10")
+                        .header("Authorization", "Bearer stub-access-token-123"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val created: OpinionDto = objectMapper.readValue(createResult.response.contentAsString)
+
+        val updateResult =
+            mockMvc
+                .perform(
+                    patch("/opinions/${created.id}")
+                        .queryParam("subjective", "updated subjective")
+                        .queryParam("objective", "updated objective")
+                        .queryParam("mark", "4.90")
+                        .header("Authorization", "Bearer stub-access-token-123"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: OpinionDto = objectMapper.readValue(updateResult.response.contentAsString)
+        assertEquals(created.id, actual.id)
+        assertEquals(CURRENT_USER_ID, actual.owner)
+        assertEquals(CURRENT_USER_NAME, actual.ownerName)
+        assertEquals(UUID.fromString("15151515-1515-1515-1515-151515151515"), actual.subject)
+        assertEquals(cappuccino1G.name, actual.subjectName)
+        assertEquals(listOf("updated subjective"), actual.subjective)
+        assertEquals(listOf("updated objective"), actual.objective)
+        assertEquals(4.9, actual.mark)
         assertEquals(OpinionStatusEnumDto.DRAFT, actual.status)
     }
 }


### PR DESCRIPTION
Target changes:

- implemented opinions-sv endpoint `PATCH /opinions/{opinionId}` as DB-backed flow
- replaced stub response in controller (`OpinionTestDataFactory.postOpinion`) with facade call
- added `OpinionFacade.updateOpinion(opinionId, subjective, objective, mark)`
- added `OpinionService.updateOpinion(...)` with transactional update logic:
    - load opinion by id (404 if missing)
    - update mark and timestamp
    - persist updated opinion
- added note replacement flow for updates:
    - `OpinionNoteRepository.deleteAllByOpinionId(...)`
    - `OpinionNoteService.replace(...)` (delete old notes + create new subjective/objective notes)
- added integration test for update path (`update opinion works()`)

Verification:

- `make docker-up`
- `make test-github` -> BUILD SUCCESSFUL