### PR TITLE
143 fix login

### DIFF
--- a/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
+++ b/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
@@ -3,6 +3,7 @@ package com.r8n.backend.users.api
 import com.r8n.backend.users.api.dto.AuthenticationTokenDto
 import com.r8n.backend.users.api.dto.LoginRequestDto
 import org.springframework.web.bind.annotation.CookieValue
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 
@@ -10,10 +11,14 @@ interface AuthApi {
     companion object {
         const val REFRESH_TOKEN_COOKIE_NAME = "refreshToken"
         private const val ROOT_PATH = "/api/auth"
+        const val CSRF_PATH = "$ROOT_PATH/csrf"
         const val LOGIN_PATH = "$ROOT_PATH/login"
         const val LOGOUT_PATH = "$ROOT_PATH/logout"
         const val REFRESH_PATH = "$ROOT_PATH/refresh"
     }
+
+    @GetMapping(CSRF_PATH)
+    fun csrf()
 
     @PostMapping(LOGIN_PATH)
     fun login(

--- a/backend/users-sv/service/src/main/kotlin/com/r8n/backend/users/controller/AuthController.kt
+++ b/backend/users-sv/service/src/main/kotlin/com/r8n/backend/users/controller/AuthController.kt
@@ -6,15 +6,24 @@ import com.r8n.backend.users.api.dto.LoginRequestDto
 import com.r8n.backend.users.security.RefreshTokenCookieFactory
 import com.r8n.backend.users.service.AuthService
 import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.context.request.RequestContextHolder
 import org.springframework.web.context.request.ServletRequestAttributes
+import java.util.UUID
 
 @RestController
 class AuthController(
     private val authService: AuthService,
     private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
 ) : AuthApi {
+    override fun csrf() {
+        currentResponse().addHeader(
+            HttpHeaders.SET_COOKIE,
+            createXsrfCookie().toString(),
+        )
+    }
+
     override fun login(request: LoginRequestDto): AuthenticationTokenDto {
         val tokens = authService.login(request)
         addRefreshTokenCookie(tokens.refreshToken)
@@ -52,7 +61,19 @@ class AuthController(
         )
     }
 
+    private fun createXsrfCookie() =
+        ResponseCookie
+            .from("XSRF-TOKEN", UUID.randomUUID().toString())
+            .httpOnly(false)
+            .secure(currentRequest().isSecure)
+            .path("/")
+            .build()
+
+    private fun currentRequest() = currentRequestAttributes().request
+
     private fun currentResponse() =
-        (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).response
+        currentRequestAttributes().response
             ?: throw IllegalStateException("No current HTTP response")
+
+    private fun currentRequestAttributes() = RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes
 }

--- a/backend/users-sv/service/src/test/kotlin/com/r8n/backend/users/AuthIntegrationTest.kt
+++ b/backend/users-sv/service/src/test/kotlin/com/r8n/backend/users/AuthIntegrationTest.kt
@@ -20,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -49,6 +50,7 @@ class AuthIntegrationTest {
                 .withInitScript("db/init-schema.sql")
 
         // yes, this is a duplicate from AuthApi, left intentional to detect changes
+        const val CSRF_PATH = "/api/auth/csrf"
         const val LOGIN_PATH = "/api/auth/login"
         const val REFRESH_PATH = "/api/auth/refresh"
         const val EMAIL = "test@test.test"
@@ -80,6 +82,19 @@ class AuthIntegrationTest {
         setCookieHeader
             .substringAfter("$REFRESH_TOKEN_COOKIE_NAME=")
             .substringBefore(";")
+
+    @Test
+    fun `csrf endpoint initializes xsrf cookie without authentication`() {
+        val response =
+            mockMvc
+                .perform(get(CSRF_PATH))
+                .andExpect(status().isOk)
+                .andReturn()
+
+        val setCookieHeader = response.response.getHeader(HttpHeaders.SET_COOKIE)!!
+        assertTrue(setCookieHeader.contains("XSRF-TOKEN="))
+        assertTrue(setCookieHeader.contains("Path=/"))
+    }
 
     @Test
     @Transactional

--- a/frontend/src/lib/api/auth.ts
+++ b/frontend/src/lib/api/auth.ts
@@ -11,22 +11,48 @@ export interface AuthenticationTokenDto {
   expiresInMilliseconds: number;
 }
 
+const XSRF_TOKEN_COOKIE_NAME = "XSRF-TOKEN";
+
 export function createAuthApi(client: HttpClient = httpClient) {
+  let csrfBootstrapPromise: Promise<void> | null = null;
+
+  async function ensureCsrfToken(): Promise<void> {
+    if (hasCookie(XSRF_TOKEN_COOKIE_NAME)) {
+      return;
+    }
+
+    csrfBootstrapPromise ??= client
+      .get<void>("/auth/csrf", {
+        credentials: "include",
+      })
+      .finally(() => {
+        csrfBootstrapPromise = null;
+      });
+
+    await csrfBootstrapPromise;
+  }
+
   return {
-    login(request: LoginRequestDto): Promise<AuthenticationTokenDto> {
+    async login(request: LoginRequestDto): Promise<AuthenticationTokenDto> {
+      await ensureCsrfToken();
+
       return client.post<AuthenticationTokenDto, LoginRequestDto>("/auth/login", {
         body: request,
         credentials: "include",
       });
     },
 
-    logout(): Promise<void> {
+    async logout(): Promise<void> {
+      await ensureCsrfToken();
+
       return client.post<void>("/auth/logout", {
         credentials: "include",
       });
     },
 
-    refresh(): Promise<AuthenticationTokenDto> {
+    async refresh(): Promise<AuthenticationTokenDto> {
+      await ensureCsrfToken();
+
       return client.post<AuthenticationTokenDto>("/auth/refresh", {
         credentials: "include",
       });
@@ -35,3 +61,21 @@ export function createAuthApi(client: HttpClient = httpClient) {
 }
 
 export const authApi = createAuthApi();
+
+function hasCookie(name: string): boolean {
+  if (typeof document === "undefined") {
+    return true;
+  }
+
+  const prefix = `${name}=`;
+
+  return document.cookie
+    .split(";")
+    .some((cookie) => {
+      const trimmedCookie = cookie.trim();
+      return (
+        trimmedCookie.startsWith(prefix) &&
+        trimmedCookie.slice(prefix.length) !== ""
+      );
+    });
+}

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -14,9 +14,24 @@ function createJsonResponse(body: unknown): Response {
   });
 }
 
+function createEmptyResponse(): Response {
+  return new Response(null, {
+    status: 204,
+  });
+}
+
+function clearCookie(name: string): void {
+  document.cookie = `${name}=; Max-Age=0; Path=/`;
+}
+
+function setCookie(name: string, value: string): void {
+  document.cookie = `${name}=${value}; Path=/`;
+}
+
 describe("API modules", () => {
   beforeEach(() => {
     clearSession();
+    clearCookie("XSRF-TOKEN");
     setSession(
       {
         accessToken: "stub-access-token-123",
@@ -26,7 +41,51 @@ describe("API modules", () => {
     );
   });
 
-  it("posts login credentials to the auth endpoint", async () => {
+  it("bootstraps csrf before posting login credentials when the xsrf cookie is missing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createEmptyResponse())
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          accessToken: "access-token",
+          expiresInMilliseconds: 1000,
+        }),
+      );
+    const client = createHttpClient({
+      baseUrl: "/api",
+      fetchFn: fetchMock,
+    });
+    const authApi = createAuthApi(client);
+
+    await authApi.login({
+      login: "test",
+      password: "1234",
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/auth/csrf",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/auth/login",
+      expect.objectContaining({
+        body: JSON.stringify({
+          login: "test",
+          password: "1234",
+        }),
+        credentials: "include",
+        method: "POST",
+      }),
+    );
+  });
+
+  it("skips csrf bootstrap when the xsrf cookie already exists", async () => {
+    setCookie("XSRF-TOKEN", "existing-xsrf-token");
     const fetchMock = vi.fn().mockResolvedValue(
       createJsonResponse({
         accessToken: "access-token",
@@ -44,26 +103,29 @@ describe("API modules", () => {
       password: "1234",
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith(
       "/api/auth/login",
       expect.objectContaining({
-        body: JSON.stringify({
-          login: "test",
-          password: "1234",
-        }),
-        credentials: "include",
         method: "POST",
       }),
     );
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const headers = new Headers(requestInit.headers);
+    expect(headers.get("X-XSRF-TOKEN")).toBe("existing-xsrf-token");
   });
 
-  it("uses cookie credentials for refresh and does not send a refresh token from JavaScript", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      createJsonResponse({
-        accessToken: "access-token",
-        expiresInMilliseconds: 1000,
-      }),
-    );
+  it("bootstraps csrf before refresh and does not send a refresh token from JavaScript", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createEmptyResponse())
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          accessToken: "access-token",
+          expiresInMilliseconds: 1000,
+        }),
+      );
     const client = createHttpClient({
       baseUrl: "/api",
       fetchFn: fetchMock,
@@ -72,7 +134,16 @@ describe("API modules", () => {
 
     await authApi.refresh();
 
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/auth/csrf",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
       "/api/auth/refresh",
       expect.objectContaining({
         credentials: "include",
@@ -80,16 +151,15 @@ describe("API modules", () => {
       }),
     );
 
-    const [, requestInit] = fetchMock.mock.calls[0];
+    const [, requestInit] = fetchMock.mock.calls[1];
     expect(requestInit.body).toBeUndefined();
   });
 
-  it("uses cookie credentials for logout", async () => {
-    const fetchMock = vi.fn().mockResolvedValue(
-      new Response(null, {
-        status: 204,
-      }),
-    );
+  it("bootstraps csrf before logout", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(createEmptyResponse())
+      .mockResolvedValueOnce(createEmptyResponse());
     const client = createHttpClient({
       baseUrl: "/api",
       fetchFn: fetchMock,
@@ -98,7 +168,16 @@ describe("API modules", () => {
 
     await authApi.logout();
 
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/auth/csrf",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+      }),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
       "/api/auth/logout",
       expect.objectContaining({
         credentials: "include",


### PR DESCRIPTION
- backend endpoint GET `/api/auth/csrf` returns `XSRF-TOKEN`;
- frontend bootstrap before login, refresh, logout;

verification:
- open `https://localhost:8443/login`;
- make sure cookies are clean;
- login with test@test.test 1234.