### PR TITLE
150 Update profile link to use regex and remove unused sidebar items

### DIFF
--- a/frontend/e2e/ui/interaction-smoke.spec.ts
+++ b/frontend/e2e/ui/interaction-smoke.spec.ts
@@ -16,7 +16,7 @@ test("sidebar and quick actions navigate through key routes without browser cons
   await page.getByRole("link", { name: "Requests" }).click();
   await expect(page).toHaveURL(/\/requests$/);
 
-  await page.getByRole("link", { name: "Profile" }).click();
+  await page.getByRole("link", { name: /open .*profile/i }).click();
   await expect(page).toHaveURL(/\/profile$/);
 
   await page.getByRole("link", { name: "Settings" }).click();

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Search, User, List, Bell, Settings, PenLine, ListPlus, LogOut, ShieldCheck } from "lucide-react";
+import { Home, Search, List, Bell, PenLine, ListPlus, LogOut, ShieldCheck } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import logo from "@/assets/logo.png";
 import { NavLink } from "@/components/NavLink";
@@ -15,7 +15,6 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarFooter,
 } from "@/components/ui/sidebar";
 import { useSidebar } from "@/components/ui/use-sidebar";
 
@@ -25,11 +24,6 @@ const mainItems = [
   { title: "My Lists", url: "/lists", icon: List },
   { title: "Requests", url: "/requests", icon: Bell },
   { title: "Moderation", url: "/moderation/opinions", icon: ShieldCheck },
-];
-
-const secondaryItems = [
-  { title: "Profile", url: "/profile", icon: User },
-  { title: "Settings", url: "/settings", icon: Settings },
 ];
 
 export function AppSidebar() {
@@ -112,50 +106,40 @@ export function AppSidebar() {
         </SidebarGroup>
 
         <SidebarGroup className="mt-auto">
-          <SidebarGroupLabel className="text-[10px] uppercase tracking-widest text-muted-foreground/60 px-6">
-            Account
-          </SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {secondaryItems.map((item) => (
-                <SidebarMenuItem key={item.title}>
-                  <SidebarMenuButton asChild>
-                    <NavLink
-                      to={item.url}
-                      className="mx-2 flex items-center gap-3 rounded-lg px-4 py-2 text-sm text-sidebar-foreground/70 transition-colors hover:bg-sidebar-accent"
-                      activeClassName="bg-sidebar-accent text-sidebar-foreground font-medium"
-                    >
-                      <item.icon className="h-4 w-4 shrink-0" />
-                      {!collapsed && <span>{item.title}</span>}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
+              <SidebarMenuItem className="mx-2 flex items-center gap-1">
+                <SidebarMenuButton asChild size="lg" tooltip={me?.name ?? "Profile"} className="min-w-0 flex-1">
+                  <NavLink
+                    to="/profile"
+                    aria-label={me?.name ? `Open profile for ${me.name}` : "Open your profile"}
+                    className="flex min-w-0 items-center gap-3 rounded-lg px-2 py-2 text-sm text-sidebar-foreground/80 transition-colors hover:bg-sidebar-accent"
+                    activeClassName="bg-sidebar-accent text-sidebar-foreground font-medium"
+                  >
+                    <UserAvatar userId={me?.id} name={me?.name ?? "…"} size="sm" />
+                    {!collapsed && (
+                      <span className="min-w-0 flex-1 truncate">
+                        {me?.name ?? "…"}
+                      </span>
+                    )}
+                  </NavLink>
+                </SidebarMenuButton>
+                {!collapsed && (
+                  <button
+                    onClick={() => logoutMutation.mutate()}
+                    disabled={logoutMutation.isPending}
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-foreground disabled:opacity-50"
+                    title="Log out"
+                    aria-label="Log out"
+                  >
+                    <LogOut className="h-4 w-4" />
+                  </button>
+                )}
+              </SidebarMenuItem>
             </SidebarMenu>
           </SidebarGroupContent>
         </SidebarGroup>
       </SidebarContent>
-
-      <SidebarFooter className="p-4 border-t border-sidebar-border">
-        <div className="flex items-center gap-3">
-          <UserAvatar userId={me?.id} name={me?.name ?? "…"} size="sm" />
-          {!collapsed && (
-            <>
-              <div className="flex-1 min-w-0">
-                <p className="truncate text-sm font-medium text-sidebar-foreground">{me?.name ?? "…"}</p>
-              </div>
-              <button
-                onClick={() => logoutMutation.mutate()}
-                disabled={logoutMutation.isPending}
-                className="shrink-0 rounded-lg p-1.5 text-muted-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-foreground"
-                title="Log out"
-              >
-                <LogOut className="h-4 w-4" />
-              </button>
-            </>
-          )}
-        </div>
-      </SidebarFooter>
     </Sidebar>
   );
 }

--- a/frontend/src/pages/EditProfile.tsx
+++ b/frontend/src/pages/EditProfile.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { ArrowLeft, CloudUpload, Loader2, Trash2 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
@@ -62,7 +62,8 @@ function validateAvatarFile(file: File): string | undefined {
 const EditProfile = () => {
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const [name, setName] = useState("Jane Doe");
+  const isNameInitializedRef = useRef(false);
+  const [name, setName] = useState("");
   const [bio, setBio] = useState("Curious eater and honest reviewer. I care about quality, atmosphere, and whether a place lives up to the hype.");
   const [location, setLocation] = useState("Berlin, Germany");
   const { data: me } = useMe();
@@ -89,6 +90,15 @@ const EditProfile = () => {
   const isAvatarMutating =
     uploadAvatarMutation.isPending || deleteAvatarMutation.isPending;
   const displayName = name.trim() || me?.name || "?";
+
+  useEffect(() => {
+    if (!me?.name || isNameInitializedRef.current) {
+      return;
+    }
+
+    setName(me.name);
+    isNameInitializedRef.current = true;
+  }, [me?.name]);
 
   const handleAvatarChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.currentTarget.files?.[0];

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,11 +1,14 @@
 import { motion } from "framer-motion";
-import { MapPin, Download } from "lucide-react";
+import { MapPin, Download, Settings } from "lucide-react";
 import { useParams, Link } from "react-router-dom";
 import UserAvatar from "@/components/UserAvatar";
 import { Button } from "@/components/ui/button";
 import { QueryState } from "@/components/server-state/QueryState";
 import { useMe, useUserProfile } from "@/lib/server-state/hooks/users";
 import { useMyOpinionLists } from "@/lib/server-state/hooks/opinion-lists";
+
+const profileActionButtonClass = "inline-flex h-11 items-center justify-center rounded-xl px-4 py-0 leading-none";
+const profileActionIconButtonClass = `${profileActionButtonClass} gap-1.5`;
 
 const Profile = () => {
   const { id } = useParams();
@@ -66,16 +69,21 @@ const Profile = () => {
                 )}
 
                 {isOwnProfile && (
-                  <div className="flex gap-3">
-                    <Link to="/profile/edit">
-                      <Button variant="outline" size="sm" className="rounded-xl">
+                  <div className="flex flex-wrap gap-3">
+                    <Button asChild variant="outline" className={profileActionButtonClass}>
+                      <Link to="/profile/edit">
                         Edit Profile
-                      </Button>
-                    </Link>
+                      </Link>
+                    </Button>
+                    <Button asChild variant="outline" className={profileActionIconButtonClass}>
+                      <Link to="/settings">
+                        <Settings className="h-3.5 w-3.5" />
+                        Settings
+                      </Link>
+                    </Button>
                     <Button
                       variant="outline"
-                      size="sm"
-                      className="rounded-xl gap-1.5"
+                      className={profileActionIconButtonClass}
                       onClick={() => {
                         const data = {
                           profile,

--- a/frontend/src/test/edit-profile-avatar.test.tsx
+++ b/frontend/src/test/edit-profile-avatar.test.tsx
@@ -104,6 +104,17 @@ describe("EditProfile avatar controls", () => {
     vi.unstubAllEnvs();
   });
 
+  it("shows initials from the current user name when there is no avatar", async () => {
+    fetchMock
+      .mockResolvedValueOnce(createUserResponse())
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    renderEditProfile();
+
+    expect(await screen.findByText("TT")).toBeInTheDocument();
+    expect(screen.queryByText("JD")).not.toBeInTheDocument();
+  });
+
   it("uploads a valid selected image file", async () => {
     fetchMock
       .mockResolvedValueOnce(createUserResponse())


### PR DESCRIPTION
Changes:
- Removed the separate Profile button from the sidebar.
- Made the avatar and username clickable.
- Clicking the avatar or username now opens the profile page.
- Moved Settings from the sidebar to the profile page.

Verification:
- start stack `make docker-up`
- check home and profile pages
