### PR TITLE
159 Refactor opinion and user interfaces to use consistent property names…

### DIFF
--- a/frontend/src/lib/api/opinion-lists.ts
+++ b/frontend/src/lib/api/opinion-lists.ts
@@ -12,7 +12,7 @@ export type OpinionListPrivacyEnumDto = "PRIVATE" | "SEARCHABLE";
 
 export interface OpinionListSummaryDto {
   grantedAccessCount: number;
-  id: Uuid;
+  listId: Uuid;
   listName: string;
   opinionsCount: number;
   owner: Uuid;
@@ -26,6 +26,7 @@ export interface OpinionListDto {
   opinionSummaries: OpinionSummaryDto[];
   owner: Uuid;
   ownerName: string;
+  privacy: OpinionListPrivacyEnumDto;
 }
 
 export interface GetOpinionListSummaryRequestDto {

--- a/frontend/src/lib/api/opinions.ts
+++ b/frontend/src/lib/api/opinions.ts
@@ -16,12 +16,10 @@ export interface WeightedOpinionReferenceDto {
 
 export interface OpinionSummaryDto {
   componentMark: number | null;
-  id: Uuid;
   opinions: WeightedOpinionReferenceDto[];
   ownMark: number | null;
   subject: Uuid;
   subjectName: string;
-  synchronizedMark: number;
 }
 
 export interface OpinionDto {
@@ -85,7 +83,7 @@ export function createOpinionsApi(client: HttpClient = httpClient) {
     adjustComponentWeight(
       request: AdjustOpinionComponentWeightRequestDto,
     ): Promise<OpinionDto> {
-      return client.patch<OpinionDto>(`/opinions/adjustWeight/${request.linkId}`, {
+      return client.patch<OpinionDto>(`/opinions/adjust-weight/${request.linkId}`, {
         auth: "required",
         query: {
           weight: request.weight,

--- a/frontend/src/lib/api/users.ts
+++ b/frontend/src/lib/api/users.ts
@@ -7,10 +7,16 @@ export interface UsernameDto {
   name: string;
 }
 
+export type UserStatusEnumDto =
+  | "ACTIVE"
+  | "SUSPENDED"
+  | "DELETION_PENDING"
+  | "DELETED";
+
 export interface UserProfileDto {
   id: Uuid;
   name: string;
-  status: string;
+  status: UserStatusEnumDto;
   lastOnline: string | null;
   about: string | null;
   location: string | null;

--- a/frontend/src/pages/CreateReview.tsx
+++ b/frontend/src/pages/CreateReview.tsx
@@ -363,7 +363,7 @@ const CreateReview = () => {
               >
                 <option value="">None</option>
                 {myLists.map((l) => (
-                  <option key={l.id} value={l.id}>{l.listName}</option>
+                  <option key={l.listId} value={l.listId}>{l.listName}</option>
                 ))}
               </select>
               <Button

--- a/frontend/src/pages/Discover.tsx
+++ b/frontend/src/pages/Discover.tsx
@@ -97,7 +97,7 @@ const Discover = () => {
         >
           <div className="grid gap-4 sm:grid-cols-2">
             {lists.map((list) => (
-              <Link key={list.id} to={`/list/${list.id}`}>
+              <Link key={list.listId} to={`/list/${list.listId}`}>
                 <OpinionListCard
                   title={list.listName}
                   description=""

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -76,7 +76,7 @@ const Dashboard = () => {
         >
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {lists.map((list) => (
-              <Link key={list.id} to={`/list/${list.id}`}>
+              <Link key={list.listId} to={`/list/${list.listId}`}>
                 <OpinionListCard
                   title={list.listName}
                   description=""

--- a/frontend/src/pages/MyLists.tsx
+++ b/frontend/src/pages/MyLists.tsx
@@ -46,7 +46,7 @@ const MyLists = () => {
         >
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {lists.map((list) => (
-              <Link key={list.id} to={`/list/${list.id}`}>
+              <Link key={list.listId} to={`/list/${list.listId}`}>
                 <OpinionListCard
                   title={list.listName}
                   description=""

--- a/frontend/src/pages/OpinionList.tsx
+++ b/frontend/src/pages/OpinionList.tsx
@@ -112,11 +112,11 @@ const OpinionListPage = () => {
                 <tbody>
                   {summaries.map((summary) => (
                     <ItemRow
-                      key={summary.id}
+                      key={summary.subject}
                       listId={listId!}
                       summary={summary}
-                      isExpanded={expandedItem === summary.id}
-                      onToggle={() => setExpandedItem(expandedItem === summary.id ? null : summary.id)}
+                      isExpanded={expandedItem === summary.subject}
+                      onToggle={() => setExpandedItem(expandedItem === summary.subject ? null : summary.subject)}
                       onAdjustWeight={handleAdjustWeight}
                       onAddReview={handleAddReview}
                       isAdjustingWeight={adjustWeight.isPending}
@@ -185,7 +185,7 @@ const ItemRow = ({
           {summary.ownMark !== null ? summary.ownMark.toFixed(1) : "—"}
         </td>
         <td className="px-4 py-3 font-mono font-semibold text-foreground">
-          {summary.synchronizedMark.toFixed(2)}
+          {summary.componentMark !== null ? summary.componentMark.toFixed(2) : "—"}
         </td>
         <td className="px-4 py-3">
           <ChevronDown

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -119,7 +119,7 @@ const Profile = () => {
               ) : (
                 <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
                   {lists.map((list) => (
-                    <Link key={list.id} to={`/list/${list.id}`}>
+                    <Link key={list.listId} to={`/list/${list.listId}`}>
                       <div className="rounded-2xl border border-border bg-card p-4 hover:bg-muted/30 transition-colors">
                         <p className="font-medium text-foreground text-sm">{list.listName}</p>
                       </div>

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -355,7 +355,7 @@ describe("API modules", () => {
       "/api/opinions/unlink/55555555-5555-5555-5555-555555555555",
     );
     expect(fetchMock.mock.calls[5][0]).toBe(
-      "/api/opinions/adjustWeight/66666666-6666-6666-6666-666666666666?weight=0.5",
+      "/api/opinions/adjust-weight/66666666-6666-6666-6666-666666666666?weight=0.5",
     );
 
     expect(fetchMock.mock.calls[1][1]).toEqual(
@@ -446,7 +446,6 @@ describe("API modules", () => {
     const accessRequestsApi = createAccessRequestsApi(client);
 
     await accessRequestsApi.getIncoming({
-      accessToken: "token",
       pageable: { page: 0, size: 20 },
     });
     await accessRequestsApi.acceptIncoming({


### PR DESCRIPTION
… and types

- Aligns frontend DTOs for opinion lists, opinions, and users with backend contracts.
- Uses listId from OpinionListSummaryDto instead of non-existent id.
- Removes non-existent OpinionSummaryDto.id and synchronizedMark; uses subject and componentMark.
- Fixes opinion weight endpoint from /opinions/adjustWeight/{linkId} to /opinions/adjust-weight/{linkId}.
- Updates connected pages and API module tests accordingly.
