### PR TITLE
125 Add Messages page and integrate into routing and sidebar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import Supplier from "./pages/Supplier";
 import OpinionList from "./pages/OpinionList";
 import MyLists from "./pages/MyLists";
 import Requests from "./pages/Requests";
+import Messages from "./pages/Messages";
 import Discover from "./pages/Discover";
 import CreateReview from "./pages/CreateReview";
 import CreateList from "./pages/CreateList";
@@ -43,6 +44,7 @@ const App = () => (
               <Route path="/list/:id" element={<OpinionList />} />
               <Route path="/lists" element={<MyLists />} />
               <Route path="/requests" element={<Requests />} />
+              <Route path="/messages" element={<Messages />} />
               <Route path="/moderation/opinions" element={<OpinionModeration />} />
               <Route path="/discover" element={<Discover />} />
               <Route path="/create" element={<CreateReview />} />

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Search, List, Bell, PenLine, ListPlus, LogOut, ShieldCheck } from "lucide-react";
+import { Home, Search, List, Bell, PenLine, ListPlus, LogOut, ShieldCheck, MessageSquare } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import logo from "@/assets/logo.png";
 import { NavLink } from "@/components/NavLink";
@@ -23,6 +23,7 @@ const mainItems = [
   { title: "Discover", url: "/discover", icon: Search },
   { title: "My Lists", url: "/lists", icon: List },
   { title: "Requests", url: "/requests", icon: Bell },
+  { title: "Messages", url: "/messages", icon: MessageSquare },
   { title: "Moderation", url: "/moderation/opinions", icon: ShieldCheck },
 ];
 

--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -4,6 +4,7 @@ import logo from "@/assets/logo.png";
 import { NavLink } from "@/components/NavLink";
 import UserAvatar from "@/components/UserAvatar";
 import { useLocation } from "react-router-dom";
+import { getUnreadMessagesCount, MOCK_MESSAGE_THREADS } from "@/lib/messages";
 import { useLogoutMutation } from "@/lib/server-state";
 import { useMe } from "@/lib/server-state/hooks/users";
 import {
@@ -30,6 +31,7 @@ const mainItems = [
 export function AppSidebar() {
   const { state } = useSidebar();
   const collapsed = state === "collapsed";
+  const unreadMessagesCount = getUnreadMessagesCount(MOCK_MESSAGE_THREADS);
   const location = useLocation();
   const navigate = useNavigate();
   const logoutMutation = useLogoutMutation({
@@ -96,6 +98,11 @@ export function AppSidebar() {
                       {item.title === "Requests" && !collapsed && (
                         <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-accent text-[10px] font-mono font-semibold text-accent-foreground">
                           3
+                        </span>
+                      )}
+                      {item.title === "Messages" && !collapsed && unreadMessagesCount > 0 && (
+                        <span className="ml-auto flex h-5 w-5 items-center justify-center rounded-full bg-accent text-[10px] font-mono font-semibold text-accent-foreground">
+                          {unreadMessagesCount}
                         </span>
                       )}
                     </NavLink>

--- a/frontend/src/lib/messages.ts
+++ b/frontend/src/lib/messages.ts
@@ -1,0 +1,109 @@
+export type MessageDirection = "incoming" | "outgoing";
+
+export interface ThreadMessage {
+  id: string;
+  direction: MessageDirection;
+  authorName: string;
+  body: string;
+  sentAt: string;
+}
+
+export interface MessageThread {
+  id: string;
+  subject: string;
+  participantName: string;
+  participantRole: string;
+  context: string;
+  updatedAt: string;
+  unreadCount: number;
+  messages: ThreadMessage[];
+}
+
+export const MOCK_MESSAGE_THREADS: MessageThread[] = [
+  {
+    id: "thread-user-1",
+    subject: "Question about your coffee grinder review",
+    participantName: "Marta Keller",
+    participantRole: "User",
+    context: "Direct message",
+    updatedAt: "18m ago",
+    unreadCount: 2,
+    messages: [
+      {
+        id: "msg-user-1",
+        direction: "incoming",
+        authorName: "Marta Keller",
+        body: "I saw your note about the grinder noise level. Was that during daily use or only while testing?",
+        sentAt: "09:42",
+      },
+      {
+        id: "msg-user-2",
+        direction: "outgoing",
+        authorName: "You",
+        body: "Daily use. It was fine for short grinding, but too loud for the small kitchen during service hours.",
+        sentAt: "09:51",
+      },
+      {
+        id: "msg-user-3",
+        direction: "incoming",
+        authorName: "Marta Keller",
+        body: "That helps, thanks. I will compare it with the quieter model before ordering.",
+        sentAt: "10:04",
+      },
+    ],
+  },
+  {
+    id: "thread-support-1",
+    subject: "Export archive request",
+    participantName: "R8N Support",
+    participantRole: "Support",
+    context: "Support conversation",
+    updatedAt: "1h ago",
+    unreadCount: 0,
+    messages: [
+      {
+        id: "msg-support-1",
+        direction: "outgoing",
+        authorName: "You",
+        body: "I requested an export of my account data this morning. Can you confirm when it will be ready?",
+        sentAt: "Yesterday",
+      },
+      {
+        id: "msg-support-2",
+        direction: "incoming",
+        authorName: "R8N Support",
+        body: "Your export is being prepared. We will notify you here when the archive is ready to download.",
+        sentAt: "Today",
+      },
+    ],
+  },
+  {
+    id: "thread-user-2",
+    subject: "Supplier recommendation follow-up",
+    participantName: "Elena Rossi",
+    participantRole: "User",
+    context: "Direct message",
+    updatedAt: "Yesterday",
+    unreadCount: 1,
+    messages: [
+      {
+        id: "msg-user-4",
+        direction: "incoming",
+        authorName: "Elena Rossi",
+        body: "Do you still recommend the packaging supplier from your March list?",
+        sentAt: "Yesterday",
+      },
+      {
+        id: "msg-user-5",
+        direction: "outgoing",
+        authorName: "You",
+        body: "Yes, but only for small batches. Their lead time became inconsistent for larger orders.",
+        sentAt: "Yesterday",
+      },
+    ],
+  },
+];
+
+export function getUnreadMessagesCount(threads: MessageThread[]): number {
+  return threads.reduce((sum, thread) => sum + thread.unreadCount, 0);
+}

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -3,8 +3,6 @@ import { motion } from "framer-motion";
 import {
   ChevronDown,
   Clock,
-  Inbox,
-  Send,
 } from "lucide-react";
 import ReviewerAvatar from "@/components/ReviewerAvatar";
 import {
@@ -129,37 +127,32 @@ const FILTERS: Array<{ id: MessageFilter; label: string }> = [
 ];
 
 function getDirectionMeta(direction: MessageDirection) {
-  if (direction === "outgoing") {
-    return {
-      label: "From you",
-      icon: Send,
-      className: "border-primary/20 bg-primary/5 text-primary",
-    };
-  }
-
-  return {
-    label: "To you",
-    icon: Inbox,
-    className: "border-accent/20 bg-accent/5 text-accent",
-  };
+  return direction === "outgoing"
+    ? {
+        bubbleClassName: "border-primary/20 bg-primary/5",
+        layoutClassName: "justify-end",
+      }
+    : {
+        bubbleClassName: "border-border bg-background",
+        layoutClassName: "justify-start",
+      };
 }
 
 const Messages = () => {
-  const firstThreadId = MOCK_THREADS[0]?.id ?? "";
-  const [openThreads, setOpenThreads] = useState<string[]>([firstThreadId]);
+  const [openThreads, setOpenThreads] = useState<string[]>([]);
   const [activeFilter, setActiveFilter] = useState<MessageFilter>("all");
 
   const filteredThreads = useMemo(
     () =>
       MOCK_THREADS.filter((thread) => {
-        const firstDirection = thread.messages[0]?.direction;
+        const lastDirection = thread.messages[thread.messages.length - 1]?.direction;
 
         if (activeFilter === "inbox") {
-          return firstDirection === "incoming";
+          return lastDirection === "incoming";
         }
 
         if (activeFilter === "outbox") {
-          return firstDirection === "outgoing";
+          return lastDirection === "outgoing";
         }
 
         if (activeFilter === "support") {
@@ -221,10 +214,8 @@ const Messages = () => {
       >
         {filteredThreads.map((thread) => {
           const isOpen = openThreads.includes(thread.id);
-          const firstMessage = thread.messages[0];
-          const remainingMessages = thread.messages.slice(1);
-          const directionMeta = getDirectionMeta(firstMessage.direction);
-          const DirectionIcon = directionMeta.icon;
+          const lastMessage = thread.messages[thread.messages.length - 1];
+          const previewMeta = getDirectionMeta(lastMessage.direction);
 
           return (
             <Collapsible
@@ -261,49 +252,50 @@ const Messages = () => {
               <CollapsibleTrigger asChild>
                 <button
                   type="button"
-                  className="flex w-full items-start gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  className="w-full px-5 py-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                   aria-label={`${isOpen ? "Collapse" : "Expand"} thread with ${thread.participantName}`}
                 >
-                  <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                    <DirectionIcon className="h-4 w-4" />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="mb-1.5 flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-medium text-foreground">
-                        {firstMessage.authorName}
-                      </span>
-                      <span
-                        className={cn(
-                          "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
-                          directionMeta.className,
-                        )}
-                      >
-                        <DirectionIcon className="h-3 w-3" />
-                        {directionMeta.label}
-                      </span>
-                      <span className="text-[10px] text-muted-foreground/70">
-                        {firstMessage.sentAt}
-                      </span>
-                    </div>
-                    <p className="line-clamp-2 text-sm leading-6 text-foreground/85">
-                      {firstMessage.body}
-                    </p>
-                  </div>
-                  <ChevronDown
+                  <div
                     className={cn(
-                      "mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
-                      isOpen && "rotate-180",
+                      "flex items-start gap-3",
+                      previewMeta.layoutClassName,
                     )}
-                  />
+                  >
+                    <div
+                      className={cn(
+                        "max-w-[82%] rounded-2xl border px-4 py-3",
+                        previewMeta.bubbleClassName,
+                      )}
+                    >
+                      <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">
+                          {lastMessage.authorName}
+                        </span>
+                        <span className="text-[10px] text-muted-foreground/70">
+                          {lastMessage.sentAt}
+                        </span>
+                      </div>
+                      {!isOpen && (
+                        <p className="line-clamp-2 text-sm leading-6 text-foreground/85">
+                          {lastMessage.body}
+                        </p>
+                      )}
+                    </div>
+                    <ChevronDown
+                      className={cn(
+                        "mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                        isOpen && "rotate-180",
+                      )}
+                    />
+                  </div>
                 </button>
               </CollapsibleTrigger>
 
               <CollapsibleContent>
                 <div className="border-t border-border/70 px-5 py-4">
                   <div className="space-y-4">
-                    {remainingMessages.map((message) => {
+                    {thread.messages.map((message) => {
                       const messageMeta = getDirectionMeta(message.direction);
-                      const MessageIcon = messageMeta.icon;
 
                       return (
                         <article
@@ -313,28 +305,15 @@ const Messages = () => {
                             message.direction === "outgoing" && "flex-row-reverse",
                           )}
                         >
-                          <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
-                            <MessageIcon className="h-4 w-4" />
-                          </div>
                           <div
                             className={cn(
-                              "max-w-[82%] rounded-2xl border border-border bg-background px-4 py-3",
-                              message.direction === "outgoing" &&
-                                "border-primary/20 bg-primary/5",
+                              "max-w-[82%] rounded-2xl border px-4 py-3",
+                              messageMeta.bubbleClassName,
                             )}
                           >
                             <div className="mb-1.5 flex flex-wrap items-center gap-2">
                               <span className="text-sm font-medium text-foreground">
                                 {message.authorName}
-                              </span>
-                              <span
-                                className={cn(
-                                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
-                                  messageMeta.className,
-                                )}
-                              >
-                                <MessageIcon className="h-3 w-3" />
-                                {messageMeta.label}
                               </span>
                               <span className="text-[10px] text-muted-foreground/70">
                                 {message.sentAt}

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -1,0 +1,362 @@
+import { useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  ChevronDown,
+  Clock,
+  Inbox,
+  Send,
+} from "lucide-react";
+import ReviewerAvatar from "@/components/ReviewerAvatar";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+type MessageDirection = "incoming" | "outgoing";
+type MessageFilter = "all" | "inbox" | "outbox" | "support";
+
+interface ThreadMessage {
+  id: string;
+  direction: MessageDirection;
+  authorName: string;
+  body: string;
+  sentAt: string;
+}
+
+interface MessageThread {
+  id: string;
+  subject: string;
+  participantName: string;
+  participantRole: string;
+  context: string;
+  updatedAt: string;
+  unreadCount: number;
+  messages: ThreadMessage[];
+}
+
+const MOCK_THREADS: MessageThread[] = [
+  {
+    id: "thread-user-1",
+    subject: "Question about your coffee grinder review",
+    participantName: "Marta Keller",
+    participantRole: "User",
+    context: "Direct message",
+    updatedAt: "18m ago",
+    unreadCount: 2,
+    messages: [
+      {
+        id: "msg-user-1",
+        direction: "incoming",
+        authorName: "Marta Keller",
+        body: "I saw your note about the grinder noise level. Was that during daily use or only while testing?",
+        sentAt: "09:42",
+      },
+      {
+        id: "msg-user-2",
+        direction: "outgoing",
+        authorName: "You",
+        body: "Daily use. It was fine for short grinding, but too loud for the small kitchen during service hours.",
+        sentAt: "09:51",
+      },
+      {
+        id: "msg-user-3",
+        direction: "incoming",
+        authorName: "Marta Keller",
+        body: "That helps, thanks. I will compare it with the quieter model before ordering.",
+        sentAt: "10:04",
+      },
+    ],
+  },
+  {
+    id: "thread-support-1",
+    subject: "Export archive request",
+    participantName: "R8N Support",
+    participantRole: "Support",
+    context: "Support conversation",
+    updatedAt: "1h ago",
+    unreadCount: 0,
+    messages: [
+      {
+        id: "msg-support-1",
+        direction: "outgoing",
+        authorName: "You",
+        body: "I requested an export of my account data this morning. Can you confirm when it will be ready?",
+        sentAt: "Yesterday",
+      },
+      {
+        id: "msg-support-2",
+        direction: "incoming",
+        authorName: "R8N Support",
+        body: "Your export is being prepared. We will notify you here when the archive is ready to download.",
+        sentAt: "Today",
+      },
+    ],
+  },
+  {
+    id: "thread-user-2",
+    subject: "Supplier recommendation follow-up",
+    participantName: "Elena Rossi",
+    participantRole: "User",
+    context: "Direct message",
+    updatedAt: "Yesterday",
+    unreadCount: 1,
+    messages: [
+      {
+        id: "msg-user-4",
+        direction: "incoming",
+        authorName: "Elena Rossi",
+        body: "Do you still recommend the packaging supplier from your March list?",
+        sentAt: "Yesterday",
+      },
+      {
+        id: "msg-user-5",
+        direction: "outgoing",
+        authorName: "You",
+        body: "Yes, but only for small batches. Their lead time became inconsistent for larger orders.",
+        sentAt: "Yesterday",
+      },
+    ],
+  },
+];
+
+const FILTERS: Array<{ id: MessageFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "inbox", label: "Inbox" },
+  { id: "outbox", label: "Outbox" },
+  { id: "support", label: "Support" },
+];
+
+function getDirectionMeta(direction: MessageDirection) {
+  if (direction === "outgoing") {
+    return {
+      label: "From you",
+      icon: Send,
+      className: "border-primary/20 bg-primary/5 text-primary",
+    };
+  }
+
+  return {
+    label: "To you",
+    icon: Inbox,
+    className: "border-accent/20 bg-accent/5 text-accent",
+  };
+}
+
+const Messages = () => {
+  const firstThreadId = MOCK_THREADS[0]?.id ?? "";
+  const [openThreads, setOpenThreads] = useState<string[]>([firstThreadId]);
+  const [activeFilter, setActiveFilter] = useState<MessageFilter>("all");
+
+  const filteredThreads = useMemo(
+    () =>
+      MOCK_THREADS.filter((thread) => {
+        const firstDirection = thread.messages[0]?.direction;
+
+        if (activeFilter === "inbox") {
+          return firstDirection === "incoming";
+        }
+
+        if (activeFilter === "outbox") {
+          return firstDirection === "outgoing";
+        }
+
+        if (activeFilter === "support") {
+          return thread.participantRole === "Support";
+        }
+
+        return true;
+      }),
+    [activeFilter],
+  );
+
+  const toggleThread = (threadId: string) => {
+    setOpenThreads((current) =>
+      current.includes(threadId)
+        ? current.filter((id) => id !== threadId)
+        : [...current, threadId],
+    );
+  };
+
+  return (
+    <div className="mx-auto max-w-4xl px-4 py-8 md:px-8 md:py-12">
+      <motion.div
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+        className="mb-10"
+      >
+        <h1 className="mb-1 text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
+          Messages
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Private conversations with other users and R8N support.
+        </p>
+      </motion.div>
+
+      <div className="mb-6 flex flex-wrap gap-2" aria-label="Message filters">
+        {FILTERS.map((filter) => (
+          <button
+            key={filter.id}
+            type="button"
+            onClick={() => setActiveFilter(filter.id)}
+            className={cn(
+              "rounded-xl border px-4 py-2 text-sm font-medium transition-colors",
+              activeFilter === filter.id
+                ? "border-primary/20 bg-primary/5 text-foreground"
+                : "border-border bg-card text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+            )}
+          >
+            {filter.label}
+          </button>
+        ))}
+      </div>
+
+      <motion.section
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.1 }}
+        className="space-y-4"
+      >
+        {filteredThreads.map((thread) => {
+          const isOpen = openThreads.includes(thread.id);
+          const firstMessage = thread.messages[0];
+          const remainingMessages = thread.messages.slice(1);
+          const directionMeta = getDirectionMeta(firstMessage.direction);
+          const DirectionIcon = directionMeta.icon;
+
+          return (
+            <Collapsible
+              key={thread.id}
+              open={isOpen}
+              onOpenChange={() => toggleThread(thread.id)}
+              className="overflow-hidden rounded-2xl border border-border bg-card shadow-card"
+            >
+              <div className="border-b border-border/70 px-5 py-4">
+                <div className="flex items-start gap-4">
+                  <ReviewerAvatar name={thread.participantName} size="md" />
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                      <h2 className="truncate text-sm font-semibold text-foreground">
+                        {thread.subject}
+                      </h2>
+                      {thread.unreadCount > 0 && (
+                        <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-accent px-1.5 text-[10px] font-mono font-semibold text-accent-foreground">
+                          {thread.unreadCount}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      {thread.participantName} · {thread.participantRole} · {thread.context}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1.5 text-[10px] text-muted-foreground/70">
+                    <Clock className="h-3 w-3" />
+                    {thread.updatedAt}
+                  </div>
+                </div>
+              </div>
+
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-start gap-4 px-5 py-4 text-left transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  aria-label={`${isOpen ? "Collapse" : "Expand"} thread with ${thread.participantName}`}
+                >
+                  <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                    <DirectionIcon className="h-4 w-4" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-medium text-foreground">
+                        {firstMessage.authorName}
+                      </span>
+                      <span
+                        className={cn(
+                          "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
+                          directionMeta.className,
+                        )}
+                      >
+                        <DirectionIcon className="h-3 w-3" />
+                        {directionMeta.label}
+                      </span>
+                      <span className="text-[10px] text-muted-foreground/70">
+                        {firstMessage.sentAt}
+                      </span>
+                    </div>
+                    <p className="line-clamp-2 text-sm leading-6 text-foreground/85">
+                      {firstMessage.body}
+                    </p>
+                  </div>
+                  <ChevronDown
+                    className={cn(
+                      "mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                      isOpen && "rotate-180",
+                    )}
+                  />
+                </button>
+              </CollapsibleTrigger>
+
+              <CollapsibleContent>
+                <div className="border-t border-border/70 px-5 py-4">
+                  <div className="space-y-4">
+                    {remainingMessages.map((message) => {
+                      const messageMeta = getDirectionMeta(message.direction);
+                      const MessageIcon = messageMeta.icon;
+
+                      return (
+                        <article
+                          key={message.id}
+                          className={cn(
+                            "flex gap-3",
+                            message.direction === "outgoing" && "flex-row-reverse",
+                          )}
+                        >
+                          <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                            <MessageIcon className="h-4 w-4" />
+                          </div>
+                          <div
+                            className={cn(
+                              "max-w-[82%] rounded-2xl border border-border bg-background px-4 py-3",
+                              message.direction === "outgoing" &&
+                                "border-primary/20 bg-primary/5",
+                            )}
+                          >
+                            <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                              <span className="text-sm font-medium text-foreground">
+                                {message.authorName}
+                              </span>
+                              <span
+                                className={cn(
+                                  "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium",
+                                  messageMeta.className,
+                                )}
+                              >
+                                <MessageIcon className="h-3 w-3" />
+                                {messageMeta.label}
+                              </span>
+                              <span className="text-[10px] text-muted-foreground/70">
+                                {message.sentAt}
+                              </span>
+                            </div>
+                            <p className="text-sm leading-6 text-foreground/85">
+                              {message.body}
+                            </p>
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          );
+        })}
+      </motion.section>
+    </div>
+  );
+};
+
+export default Messages;

--- a/frontend/src/pages/Messages.tsx
+++ b/frontend/src/pages/Messages.tsx
@@ -3,121 +3,30 @@ import { motion } from "framer-motion";
 import {
   ChevronDown,
   Clock,
+  Plus,
+  SendHorizontal,
 } from "lucide-react";
 import ReviewerAvatar from "@/components/ReviewerAvatar";
+import { Button } from "@/components/ui/button";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { MOCK_MESSAGE_THREADS, type MessageDirection, type MessageThread, type ThreadMessage } from "@/lib/messages";
 import { cn } from "@/lib/utils";
 
-type MessageDirection = "incoming" | "outgoing";
 type MessageFilter = "all" | "inbox" | "outbox" | "support";
-
-interface ThreadMessage {
-  id: string;
-  direction: MessageDirection;
-  authorName: string;
-  body: string;
-  sentAt: string;
-}
-
-interface MessageThread {
-  id: string;
-  subject: string;
-  participantName: string;
-  participantRole: string;
-  context: string;
-  updatedAt: string;
-  unreadCount: number;
-  messages: ThreadMessage[];
-}
-
-const MOCK_THREADS: MessageThread[] = [
-  {
-    id: "thread-user-1",
-    subject: "Question about your coffee grinder review",
-    participantName: "Marta Keller",
-    participantRole: "User",
-    context: "Direct message",
-    updatedAt: "18m ago",
-    unreadCount: 2,
-    messages: [
-      {
-        id: "msg-user-1",
-        direction: "incoming",
-        authorName: "Marta Keller",
-        body: "I saw your note about the grinder noise level. Was that during daily use or only while testing?",
-        sentAt: "09:42",
-      },
-      {
-        id: "msg-user-2",
-        direction: "outgoing",
-        authorName: "You",
-        body: "Daily use. It was fine for short grinding, but too loud for the small kitchen during service hours.",
-        sentAt: "09:51",
-      },
-      {
-        id: "msg-user-3",
-        direction: "incoming",
-        authorName: "Marta Keller",
-        body: "That helps, thanks. I will compare it with the quieter model before ordering.",
-        sentAt: "10:04",
-      },
-    ],
-  },
-  {
-    id: "thread-support-1",
-    subject: "Export archive request",
-    participantName: "R8N Support",
-    participantRole: "Support",
-    context: "Support conversation",
-    updatedAt: "1h ago",
-    unreadCount: 0,
-    messages: [
-      {
-        id: "msg-support-1",
-        direction: "outgoing",
-        authorName: "You",
-        body: "I requested an export of my account data this morning. Can you confirm when it will be ready?",
-        sentAt: "Yesterday",
-      },
-      {
-        id: "msg-support-2",
-        direction: "incoming",
-        authorName: "R8N Support",
-        body: "Your export is being prepared. We will notify you here when the archive is ready to download.",
-        sentAt: "Today",
-      },
-    ],
-  },
-  {
-    id: "thread-user-2",
-    subject: "Supplier recommendation follow-up",
-    participantName: "Elena Rossi",
-    participantRole: "User",
-    context: "Direct message",
-    updatedAt: "Yesterday",
-    unreadCount: 1,
-    messages: [
-      {
-        id: "msg-user-4",
-        direction: "incoming",
-        authorName: "Elena Rossi",
-        body: "Do you still recommend the packaging supplier from your March list?",
-        sentAt: "Yesterday",
-      },
-      {
-        id: "msg-user-5",
-        direction: "outgoing",
-        authorName: "You",
-        body: "Yes, but only for small batches. Their lead time became inconsistent for larger orders.",
-        sentAt: "Yesterday",
-      },
-    ],
-  },
-];
 
 const FILTERS: Array<{ id: MessageFilter; label: string }> = [
   { id: "all", label: "All" },
@@ -139,12 +48,17 @@ function getDirectionMeta(direction: MessageDirection) {
 }
 
 const Messages = () => {
+  const [threads, setThreads] = useState<MessageThread[]>(MOCK_MESSAGE_THREADS);
   const [openThreads, setOpenThreads] = useState<string[]>([]);
   const [activeFilter, setActiveFilter] = useState<MessageFilter>("all");
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const [isNewMessageDialogOpen, setIsNewMessageDialogOpen] = useState(false);
+  const [newRecipient, setNewRecipient] = useState("");
+  const [newMessage, setNewMessage] = useState("");
 
   const filteredThreads = useMemo(
     () =>
-      MOCK_THREADS.filter((thread) => {
+      threads.filter((thread) => {
         const lastDirection = thread.messages[thread.messages.length - 1]?.direction;
 
         if (activeFilter === "inbox") {
@@ -161,7 +75,7 @@ const Messages = () => {
 
         return true;
       }),
-    [activeFilter],
+    [activeFilter, threads],
   );
 
   const toggleThread = (threadId: string) => {
@@ -172,20 +86,122 @@ const Messages = () => {
     );
   };
 
+  const updateDraft = (threadId: string, value: string) => {
+    setDrafts((current) => ({
+      ...current,
+      [threadId]: value,
+    }));
+  };
+
+  const sendMessage = (threadId: string) => {
+    const draft = drafts[threadId]?.trim();
+
+    if (!draft) {
+      return;
+    }
+
+    setThreads((current) => {
+      const thread = current.find((item) => item.id === threadId);
+      if (!thread) {
+        return current;
+      }
+
+      const nextMessage: ThreadMessage = {
+        id: `msg-${threadId}-${Date.now()}`,
+        direction: "outgoing",
+        authorName: "You",
+        body: draft,
+        sentAt: "Just now",
+      };
+
+      const updatedThread: MessageThread = {
+        ...thread,
+        updatedAt: "Just now",
+        unreadCount: 0,
+        messages: [...thread.messages, nextMessage],
+      };
+
+      return [
+        updatedThread,
+        ...current.filter((item) => item.id !== threadId),
+      ];
+    });
+
+    setDrafts((current) => ({
+      ...current,
+      [threadId]: "",
+    }));
+  };
+
+  const createThread = () => {
+    const recipientName = newRecipient.trim();
+    const messageBody = newMessage.trim();
+
+    if (!recipientName || !messageBody) {
+      return;
+    }
+
+    const normalizedRecipient = recipientName.toLowerCase();
+    const isSupportThread = normalizedRecipient.includes("support");
+    const threadId = `thread-new-${Date.now()}`;
+    const createdThread: MessageThread = {
+      id: threadId,
+      subject: isSupportThread
+        ? "New support conversation"
+        : `Conversation with ${recipientName}`,
+      participantName: recipientName,
+      participantRole: isSupportThread ? "Support" : "User",
+      context: isSupportThread ? "Support conversation" : "Direct message",
+      updatedAt: "Just now",
+      unreadCount: 0,
+      messages: [
+        {
+          id: `msg-${threadId}-1`,
+          direction: "outgoing",
+          authorName: "You",
+          body: messageBody,
+          sentAt: "Just now",
+        },
+      ],
+    };
+
+    setThreads((current) => [createdThread, ...current]);
+    setOpenThreads((current) => [threadId, ...current]);
+    setActiveFilter("all");
+    setDrafts((current) => ({
+      ...current,
+      [threadId]: "",
+    }));
+    setNewRecipient("");
+    setNewMessage("");
+    setIsNewMessageDialogOpen(false);
+  };
+
   return (
     <div className="mx-auto max-w-4xl px-4 py-8 md:px-8 md:py-12">
       <motion.div
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4 }}
-        className="mb-10"
+        className="mb-10 flex items-start justify-between gap-4"
       >
-        <h1 className="mb-1 text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
-          Messages
-        </h1>
-        <p className="text-sm text-muted-foreground">
-          Private conversations with other users and R8N support.
-        </p>
+        <div>
+          <h1 className="mb-1 text-2xl font-semibold tracking-tight text-foreground md:text-3xl">
+            Messages
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Private conversations with other users and R8N support.
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="rounded-xl"
+          onClick={() => setIsNewMessageDialogOpen(true)}
+        >
+          <Plus className="h-4 w-4" />
+          New message
+        </Button>
       </motion.div>
 
       <div className="mb-6 flex flex-wrap gap-2" aria-label="Message filters">
@@ -327,13 +343,89 @@ const Messages = () => {
                       );
                     })}
                   </div>
-
+                  <div className="mt-5 border-t border-border/70 pt-4">
+                    <div className="rounded-2xl border border-border bg-background p-3">
+                      <Textarea
+                        value={drafts[thread.id] ?? ""}
+                        onChange={(event) => updateDraft(thread.id, event.target.value)}
+                        placeholder={`Message ${thread.participantName}...`}
+                        className="min-h-[96px] resize-none border-0 px-0 py-0 shadow-none focus-visible:ring-0"
+                      />
+                      <div className="mt-3 flex justify-end">
+                        <Button
+                          type="button"
+                          size="sm"
+                          className="rounded-xl"
+                          disabled={!drafts[thread.id]?.trim()}
+                          onClick={() => sendMessage(thread.id)}
+                        >
+                          <SendHorizontal className="h-4 w-4" />
+                          Send
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </CollapsibleContent>
             </Collapsible>
           );
         })}
       </motion.section>
+
+      <Dialog open={isNewMessageDialogOpen} onOpenChange={setIsNewMessageDialogOpen}>
+        <DialogContent className="rounded-2xl">
+          <DialogHeader>
+            <DialogTitle>New message</DialogTitle>
+            <DialogDescription>
+              Start a private conversation with another user or R8N support.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label htmlFor="new-message-recipient" className="text-sm font-medium text-foreground">
+                Recipient
+              </label>
+              <Input
+                id="new-message-recipient"
+                value={newRecipient}
+                onChange={(event) => setNewRecipient(event.target.value)}
+                placeholder="Enter a name or R8N Support"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="new-message-body" className="text-sm font-medium text-foreground">
+                Message
+              </label>
+              <Textarea
+                id="new-message-body"
+                value={newMessage}
+                onChange={(event) => setNewMessage(event.target.value)}
+                placeholder="Write the first message..."
+                className="min-h-[120px] resize-none"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-xl"
+              onClick={() => setIsNewMessageDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-xl"
+              disabled={!newRecipient.trim() || !newMessage.trim()}
+              onClick={createThread}
+            >
+              <SendHorizontal className="h-4 w-4" />
+              Start thread
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };

--- a/frontend/src/test/messages-lib.test.ts
+++ b/frontend/src/test/messages-lib.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { getUnreadMessagesCount, MOCK_MESSAGE_THREADS } from "@/lib/messages";
+
+describe("messages helpers", () => {
+  it("sums unread incoming messages across threads", () => {
+    expect(getUnreadMessagesCount(MOCK_MESSAGE_THREADS)).toBe(3);
+  });
+});

--- a/frontend/src/test/messages.test.tsx
+++ b/frontend/src/test/messages.test.tsx
@@ -36,4 +36,39 @@ describe("Messages page", () => {
     expect(screen.queryByText("Question about your coffee grinder review")).not.toBeInTheDocument();
     expect(screen.queryByText("Supplier recommendation follow-up")).not.toBeInTheDocument();
   });
+
+  it("sends a new message in an expanded thread", () => {
+    render(<Messages />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand thread with R8N Support" }));
+    fireEvent.change(
+      screen.getByPlaceholderText("Message R8N Support..."),
+      { target: { value: "Thanks, please send it here once it is ready." } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(
+      screen.getByText("Thanks, please send it here once it is ready."),
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Message R8N Support...")).toHaveValue("");
+  });
+
+  it("creates a new thread from the new message dialog", () => {
+    render(<Messages />);
+
+    fireEvent.click(screen.getByRole("button", { name: "New message" }));
+    fireEvent.change(screen.getByLabelText("Recipient"), {
+      target: { value: "Lina Hartmann" },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "Hi, I wanted to ask about your supplier shortlist." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+
+    expect(screen.getByText("Conversation with Lina Hartmann")).toBeInTheDocument();
+    expect(
+      screen.getByText("Hi, I wanted to ask about your supplier shortlist."),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Collapse thread with Lina Hartmann" })).toBeInTheDocument();
+  });
 });

--- a/frontend/src/test/messages.test.tsx
+++ b/frontend/src/test/messages.test.tsx
@@ -3,25 +3,28 @@ import { describe, expect, it } from "vitest";
 import Messages from "@/pages/Messages";
 
 describe("Messages page", () => {
-  it("expands a thread when the first message is clicked", () => {
+  it("shows the latest message in a collapsed thread and expands on click", () => {
     render(<Messages />);
 
     expect(
-      screen.queryByText("Your export is being prepared. We will notify you here when the archive is ready to download."),
+      screen.getByText("Your export is being prepared. We will notify you here when the archive is ready to download."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("I requested an export of my account data this morning. Can you confirm when it will be ready?"),
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Expand thread with R8N Support" }));
 
     expect(
-      screen.getByText("Your export is being prepared. We will notify you here when the archive is ready to download."),
+      screen.getByText("I requested an export of my account data this morning. Can you confirm when it will be ready?"),
     ).toBeInTheDocument();
   });
 
-  it("shows incoming and outgoing direction labels", () => {
+  it("does not show incoming and outgoing direction labels", () => {
     render(<Messages />);
 
-    expect(screen.getAllByText("To you").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("From you").length).toBeGreaterThan(0);
+    expect(screen.queryByText("To you")).not.toBeInTheDocument();
+    expect(screen.queryByText("From you")).not.toBeInTheDocument();
   });
 
   it("filters support conversations", () => {

--- a/frontend/src/test/messages.test.tsx
+++ b/frontend/src/test/messages.test.tsx
@@ -1,0 +1,36 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Messages from "@/pages/Messages";
+
+describe("Messages page", () => {
+  it("expands a thread when the first message is clicked", () => {
+    render(<Messages />);
+
+    expect(
+      screen.queryByText("Your export is being prepared. We will notify you here when the archive is ready to download."),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand thread with R8N Support" }));
+
+    expect(
+      screen.getByText("Your export is being prepared. We will notify you here when the archive is ready to download."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows incoming and outgoing direction labels", () => {
+    render(<Messages />);
+
+    expect(screen.getAllByText("To you").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("From you").length).toBeGreaterThan(0);
+  });
+
+  it("filters support conversations", () => {
+    render(<Messages />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Support" }));
+
+    expect(screen.getByText("Export archive request")).toBeInTheDocument();
+    expect(screen.queryByText("Question about your coffee grinder review")).not.toBeInTheDocument();
+    expect(screen.queryByText("Supplier recommendation follow-up")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
- Added a new `/messages` page for private user and support conversations.
- Implemented threaded message cards with expandable conversation history.
- Added `All`, `Inbox`, `Outbox`, and `Support` filters using mocked page data.
- Added the Messages route, sidebar navigation item, and focused unit tests.