### PR TITLE
195 Hide Dashboard nav link and Suggested Reviewers section until impleme…

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -21,7 +21,8 @@ import {
 import { useSidebar } from "@/components/ui/use-sidebar";
 
 const mainItems = [
-  { title: "Dashboard", url: "/", icon: Home },
+  // TODO #195: Dashboard is not implemented yet — hide from nav until ready
+  // { title: "Dashboard", url: "/", icon: Home },
   { title: "Discover", url: "/discover", icon: Search },
   { title: "My Lists", url: "/lists", icon: List },
   { title: "Requests", url: "/requests", icon: Bell },

--- a/frontend/src/pages/Discover.tsx
+++ b/frontend/src/pages/Discover.tsx
@@ -7,13 +7,13 @@ import { QueryState } from "@/components/server-state/QueryState";
 import { Link } from "react-router-dom";
 import { useSearchOpinionLists } from "@/lib/server-state/hooks/opinion-lists";
 
-// Trending reviewers: no user search endpoint yet
-const trendingReviewers = [
-  { id: "alex-kruger", name: "Alex Krüger", reviews: 47, bio: "Berlin food writer" },
-  { id: "mia-svensson", name: "Mia Svensson", reviews: 31, bio: "Nordic cuisine enthusiast" },
-  { id: "tobias-richter", name: "Tobias Richter", reviews: 22, bio: "Weekend explorer" },
-  { id: "sophie-chen", name: "Sophie Chen", reviews: 19, bio: "Coffee & dessert focused" },
-];
+// TODO #195: Suggested Reviewers not implemented yet — hidden until user search endpoint is available
+// const trendingReviewers = [
+//   { id: "alex-kruger", name: "Alex Krüger", reviews: 47, bio: "Berlin food writer" },
+//   { id: "mia-svensson", name: "Mia Svensson", reviews: 31, bio: "Nordic cuisine enthusiast" },
+//   { id: "tobias-richter", name: "Tobias Richter", reviews: 22, bio: "Weekend explorer" },
+//   { id: "sophie-chen", name: "Sophie Chen", reviews: 19, bio: "Coffee & dessert focused" },
+// ];
 
 const Discover = () => {
   const [query, setQuery] = useState("");
@@ -49,8 +49,8 @@ const Discover = () => {
         />
       </div>
 
-      {/* Suggested Reviewers — no user search endpoint yet */}
-      {!query && (
+      {/* TODO #195: Suggested Reviewers hidden until user search endpoint is available */}
+      {/* {!query && (
         <motion.section
           initial={{ opacity: 0, y: 8 }}
           animate={{ opacity: 1, y: 0 }}
@@ -75,7 +75,7 @@ const Discover = () => {
             ))}
           </div>
         </motion.section>
-      )}
+      )} */}
 
       {/* Lists */}
       <motion.section

--- a/frontend/src/pages/Index.tsx
+++ b/frontend/src/pages/Index.tsx
@@ -13,6 +13,7 @@ function getGreeting() {
   return "Good evening";
 }
 
+// TODO #195: Dashboard is not connected — hidden from the sidebar nav until implementation is complete
 const Dashboard = () => {
   const { data, isLoading, isError, error, refetch } = useMyOpinionLists({
     pageable: { page: 0, size: 3 },


### PR DESCRIPTION
Commenting out two unfinished features to keep the UI clean for the current release:                        
                                                                                                              
  - Dashboard removed from the sidebar nav (page untouched, route still exists)                               
  - Suggested Reviewers section hidden in Discover (no user search endpoint yet) 