### PR TITLE
Add weight parameter to SyncOpinionListsRequestDto and update API call

### DIFF
--- a/frontend/src/lib/api/opinion-lists.ts
+++ b/frontend/src/lib/api/opinion-lists.ts
@@ -71,6 +71,7 @@ export interface SearchOpinionListsRequestDto {
 export interface SyncOpinionListsRequestDto {
   addedListId: Uuid;
   existingListId: Uuid;
+  weight: number;
 }
 
 export interface UnsyncOpinionListsRequestDto {
@@ -171,6 +172,7 @@ export function createOpinionListsApi(client: HttpClient = httpClient) {
           auth: "required",
           query: {
             addedListId: request.addedListId,
+            weight: request.weight,
           },
         },
       );

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -471,6 +471,7 @@ describe("API modules", () => {
     await opinionListsApi.sync({
       addedListId: "77777777-7777-7777-7777-777777777777",
       existingListId: "88888888-8888-8888-8888-888888888888",
+      weight: 0.75,
     });
     await opinionListsApi.unlinkOpinion({
       listId: "99999999-9999-9999-9999-999999999999",
@@ -497,7 +498,7 @@ describe("API modules", () => {
       "/api/opinion-lists/66666666-6666-6666-6666-666666666666/set-privacy?privacy=PRIVATE",
     );
     expect(fetchMock.mock.calls[5][0]).toBe(
-      "/api/opinion-lists/88888888-8888-8888-8888-888888888888/sync?addedListId=77777777-7777-7777-7777-777777777777",
+      "/api/opinion-lists/88888888-8888-8888-8888-888888888888/sync?addedListId=77777777-7777-7777-7777-777777777777&weight=0.75",
     );
     expect(fetchMock.mock.calls[6][0]).toBe(
       "/api/opinion-lists/99999999-9999-9999-9999-999999999999/unlink?opinionId=aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",


### PR DESCRIPTION
## Summary
- Make `weight` required in the frontend opinion-lists sync contract
- Send `weight` as a query parameter when syncing lists
- Update API route regression test for the new sync URL
