### PR TITLE
search lists by name

### DIFF
--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/access/database/AccessRequestRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/access/database/AccessRequestRepository.kt
@@ -59,4 +59,9 @@ interface AccessRequestRepository : JpaRepository<AccessRequestPersistence, UUID
         list: UUID,
         status: RequestStatusEnum,
     ): Boolean
+
+    fun countByListAndStatus(
+        list: UUID,
+        status: RequestStatusEnum,
+    ): Long
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
@@ -55,9 +55,14 @@ class StubOpinionListController(
         authorId: UUID?,
         authorNameSubstring: String?,
         pageable: PageRequestDto,
-    ) = PageImpl(
-        listOf(OpinionListTestDataFactory.getListSummary()),
-    ).toResponse()
+    ): com.r8n.backend.core.api.PageResponseDto<OpinionListSummaryDto> {
+        // Only implement search by name substring as per scope
+        if (nameSubstring != null && nameSubstring.isNotBlank()) {
+            return opinionListFacade.searchOpinionListsByName(nameSubstring, pageable)
+        }
+        // Return empty page if no search criteria provided
+        return PageImpl<OpinionListSummaryDto>(emptyList()).toResponse()
+    }
 
     @PreAuthorize(IS_USER)
     override fun syncWithOpinionList(
@@ -73,5 +78,25 @@ class StubOpinionListController(
     ) = opinionListFacade.unsyncWithOpinionList(getCurrentUserId(), existingListId, removedListId)
 
     @PreAuthorize(IS_USER)
-    override fun getMine(pageable: PageRequestDto) = search(null, null, null, pageable)
+    override fun getMine(pageable: PageRequestDto): com.r8n.backend.core.api.PageResponseDto<OpinionListSummaryDto> {
+        val fullLists = opinionListFacade.getListsFull(getCurrentUserId(), pageable)
+        // Convert full DTOs to summary DTOs
+        return com.r8n.backend.core.api.PageResponseDto(
+            items =
+                fullLists.items.map { full ->
+                    OpinionListSummaryDto(
+                        listId = full.id,
+                        listName = full.listName,
+                        owner = full.owner,
+                        ownerName = full.ownerName,
+                        opinionsCount = full.opinionSummaries.size.toLong(),
+                        grantedAccessCount = 0, // TODO: Implement granted access count
+                        privacy = full.privacy,
+                    )
+                },
+            total = fullLists.total,
+            page = fullLists.page,
+            size = fullLists.size,
+        )
+    }
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
@@ -2,6 +2,8 @@ package com.r8n.backend.opinions.lists.controller
 
 import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.utils.toResponse
+import com.r8n.backend.opinions.access.database.AccessRequestRepository
+import com.r8n.backend.opinions.access.domain.RequestStatusEnum
 import com.r8n.backend.opinions.api.lists.OpinionListsApi
 import com.r8n.backend.opinions.api.lists.dto.OpinionListPrivacyEnumDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListSummaryDto
@@ -17,6 +19,7 @@ import java.util.UUID
 @RestController
 class StubOpinionListController(
     private val opinionListFacade: OpinionListFacade,
+    private val accessRequestRepository: AccessRequestRepository,
 ) : OpinionListsApi {
     @PreAuthorize(IS_USER)
     override fun getListSummary(listId: UUID): OpinionListSummaryDto = OpinionListTestDataFactory.getListSummary(listId)
@@ -84,13 +87,18 @@ class StubOpinionListController(
         return com.r8n.backend.core.api.PageResponseDto(
             items =
                 fullLists.items.map { full ->
+                    val grantedAccessCount =
+                        accessRequestRepository.countByListAndStatus(
+                            full.id,
+                            RequestStatusEnum.ACCEPTED,
+                        )
                     OpinionListSummaryDto(
                         listId = full.id,
                         listName = full.listName,
                         owner = full.owner,
                         ownerName = full.ownerName,
                         opinionsCount = full.opinionSummaries.size.toLong(),
-                        grantedAccessCount = 0, // TODO: Implement granted access count
+                        grantedAccessCount = grantedAccessCount.toInt(),
                         privacy = full.privacy,
                     )
                 },

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionListRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionListRepository.kt
@@ -1,9 +1,12 @@
 package com.r8n.backend.opinions.lists.database
 
+import com.r8n.backend.opinions.lists.domain.OpinionListPrivacyEnum
 import com.r8n.backend.opinions.lists.persistence.OpinionListPersistence
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface OpinionListRepository : JpaRepository<OpinionListPersistence, UUID> {
@@ -19,6 +22,20 @@ interface OpinionListRepository : JpaRepository<OpinionListPersistence, UUID> {
 
     fun findByNameContainingIgnoreCase(
         name: String,
+        pageable: Pageable,
+    ): Page<OpinionListPersistence>
+
+    @Query(
+        """
+        SELECT ol FROM OpinionListPersistence ol
+        WHERE LOWER(ol.name) LIKE LOWER(CONCAT('%', :nameSubstring, '%'))
+        AND (ol.owner = :requesterId OR ol.privacy = :searchablePrivacy)
+        """,
+    )
+    fun findByNameContainingIgnoreCaseAndPrivacyFilter(
+        @Param("nameSubstring") nameSubstring: String,
+        @Param("requesterId") requesterId: UUID,
+        @Param("searchablePrivacy") searchablePrivacy: OpinionListPrivacyEnum,
         pageable: Pageable,
     ): Page<OpinionListPersistence>
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionListRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionListRepository.kt
@@ -16,4 +16,9 @@ interface OpinionListRepository : JpaRepository<OpinionListPersistence, UUID> {
         owner: UUID,
         pageable: Pageable,
     ): Page<OpinionListPersistence>
+
+    fun findByNameContainingIgnoreCase(
+        name: String,
+        pageable: Pageable,
+    ): Page<OpinionListPersistence>
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionsToOpinionListsRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/database/OpinionsToOpinionListsRepository.kt
@@ -8,4 +8,6 @@ interface OpinionsToOpinionListsRepository : JpaRepository<OpinionsToOpinionList
     fun findAllByOpinionList(opinionListId: UUID): List<OpinionsToOpinionListsPersistence>
 
     fun findAllByOpinion(opinionId: UUID): List<OpinionsToOpinionListsPersistence>
+
+    fun countByOpinionList(opinionListId: UUID): Long
 }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListFacade.kt
@@ -38,10 +38,12 @@ class OpinionListFacade(
         val results = opinionListService.searchOpinionListsByName(nameSubstring, requesterId, pageable.toPageable())
 
         return results
-            .map { persistence ->
-                val opinionsCount = 0L // TODO: Implement opinion count calculation
-                val grantedAccessCount = 0 // TODO: Implement granted access count calculation
-                opinionListMapper.toSummaryDto(persistence, opinionsCount, grantedAccessCount)
+            .map { searchResult ->
+                opinionListMapper.toSummaryDto(
+                    searchResult.persistence,
+                    searchResult.opinionsCount,
+                    searchResult.grantedAccessCount.toInt(),
+                )
             }.toResponse()
     }
 

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListFacade.kt
@@ -5,7 +5,9 @@ import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.core.utils.toPageable
 import com.r8n.backend.core.utils.toResponse
 import com.r8n.backend.opinions.api.lists.dto.OpinionListDto
+import com.r8n.backend.opinions.api.lists.dto.OpinionListSummaryDto
 import com.r8n.backend.opinions.lists.service.OpinionListService
+import com.r8n.backend.security.CurrentUserIdentifier
 import org.springframework.stereotype.Component
 import java.util.UUID
 
@@ -27,6 +29,21 @@ class OpinionListFacade(
             .getListsFull(ownerId, pageable.toPageable())
             .map { opinionListMapper.toDto(it) }
             .toResponse()
+
+    fun searchOpinionListsByName(
+        nameSubstring: String,
+        pageable: PageRequestDto,
+    ): PageResponseDto<OpinionListSummaryDto> {
+        val requesterId = CurrentUserIdentifier.getCurrentUserId()
+        val results = opinionListService.searchOpinionListsByName(nameSubstring, requesterId, pageable.toPageable())
+
+        return results
+            .map { persistence ->
+                val opinionsCount = 0L // TODO: Implement opinion count calculation
+                val grantedAccessCount = 0 // TODO: Implement granted access count calculation
+                opinionListMapper.toSummaryDto(persistence, opinionsCount, grantedAccessCount)
+            }.toResponse()
+    }
 
     fun syncWithOpinionList(
         userId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListMapper.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/facade/OpinionListMapper.kt
@@ -2,10 +2,12 @@ package com.r8n.backend.opinions.lists.facade
 
 import com.r8n.backend.opinions.api.lists.dto.OpinionListDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListPrivacyEnumDto
+import com.r8n.backend.opinions.api.lists.dto.OpinionListSummaryDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionSummaryDto
 import com.r8n.backend.opinions.lists.domain.OpinionList
 import com.r8n.backend.opinions.lists.domain.OpinionListPrivacyEnum
 import com.r8n.backend.opinions.lists.domain.OpinionSummary
+import com.r8n.backend.opinions.lists.persistence.OpinionListPersistence
 import com.r8n.backend.opinions.opinions.facade.OpinionMapper
 import com.r8n.backend.opinions.opinions.service.SubjectService
 import com.r8n.backend.users.integration.api.UsersInternalApi
@@ -25,6 +27,23 @@ class OpinionListMapper(
                 owner = owner,
                 ownerName = usersClient.getUserName(owner),
                 opinionSummaries = opinionSummaries.map { toDto(it) },
+                privacy = privacy.toDto(),
+            )
+        }
+
+    fun toSummaryDto(
+        persistence: OpinionListPersistence,
+        opinionsCount: Long,
+        grantedAccessCount: Int,
+    ): OpinionListSummaryDto =
+        with(persistence) {
+            OpinionListSummaryDto(
+                listId = id!!,
+                listName = name,
+                owner = owner,
+                ownerName = usersClient.getUserName(owner),
+                opinionsCount = opinionsCount,
+                grantedAccessCount = grantedAccessCount,
                 privacy = privacy.toDto(),
             )
         }

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/service/OpinionListService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/service/OpinionListService.kt
@@ -290,6 +290,24 @@ class OpinionListService(
             .findByOwner(ownerId, pageable)
             .map { getList(it.id!!, ownerId) }
 
+    fun searchOpinionListsByName(
+        nameSubstring: String,
+        requesterId: UUID,
+        pageable: Pageable,
+    ): Page<OpinionListPersistence> {
+        val results = opinionListRepository.findByNameContainingIgnoreCase(nameSubstring, pageable)
+
+        // Filter by privacy: only show SEARCHABLE lists to non-owners
+        val filtered =
+            results.content.filter { list ->
+                accessService.ownsOpinionList(requesterId, list.id!!) ||
+                    list.privacy == OpinionListPrivacyEnum.SEARCHABLE
+            }
+
+        return org.springframework.data.domain
+            .PageImpl(filtered, pageable, filtered.size.toLong())
+    }
+
     private companion object {
         fun toDomain(
             list: OpinionListPersistence,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/service/OpinionListService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/service/OpinionListService.kt
@@ -1,6 +1,8 @@
 package com.r8n.backend.opinions.lists.service
 
+import com.r8n.backend.opinions.access.database.AccessRequestRepository
 import com.r8n.backend.opinions.access.domain.OpinionListPermissionEnum
+import com.r8n.backend.opinions.access.domain.RequestStatusEnum
 import com.r8n.backend.opinions.access.service.AccessService
 import com.r8n.backend.opinions.lists.database.OpinionListRepository
 import com.r8n.backend.opinions.lists.database.OpinionListSyncRepository
@@ -22,6 +24,12 @@ import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
+data class OpinionListSearchResult(
+    val persistence: OpinionListPersistence,
+    val opinionsCount: Long,
+    val grantedAccessCount: Long,
+)
+
 @Service
 class OpinionListService(
     private val opinionListRepository: OpinionListRepository,
@@ -29,6 +37,7 @@ class OpinionListService(
     private val opinionsAssignmentRepository: OpinionsToOpinionListsRepository,
     private val accessService: AccessService,
     private val syncRepository: OpinionListSyncRepository,
+    private val accessRequestRepository: AccessRequestRepository,
 ) {
     fun syncWithOpinionList(
         userId: UUID,
@@ -294,18 +303,34 @@ class OpinionListService(
         nameSubstring: String,
         requesterId: UUID,
         pageable: Pageable,
-    ): Page<OpinionListPersistence> {
-        val results = opinionListRepository.findByNameContainingIgnoreCase(nameSubstring, pageable)
+    ): Page<OpinionListSearchResult> {
+        // Privacy filtering is now done in the database query
+        val results =
+            opinionListRepository.findByNameContainingIgnoreCaseAndPrivacyFilter(
+                nameSubstring,
+                requesterId,
+                OpinionListPrivacyEnum.SEARCHABLE,
+                pageable,
+            )
 
-        // Filter by privacy: only show SEARCHABLE lists to non-owners
-        val filtered =
-            results.content.filter { list ->
-                accessService.ownsOpinionList(requesterId, list.id!!) ||
-                    list.privacy == OpinionListPrivacyEnum.SEARCHABLE
+        // Calculate counts for each result
+        val searchResults =
+            results.content.map { persistence ->
+                val listId = persistence.id!!
+                val opinionsCount = opinionsAssignmentRepository.countByOpinionList(listId)
+                val grantedAccessCount =
+                    accessRequestRepository.countByListAndStatus(
+                        listId,
+                        RequestStatusEnum.ACCEPTED,
+                    )
+                OpinionListSearchResult(persistence, opinionsCount, grantedAccessCount)
             }
 
-        return org.springframework.data.domain
-            .PageImpl(filtered, pageable, filtered.size.toLong())
+        return org.springframework.data.domain.PageImpl(
+            searchResults,
+            pageable,
+            results.totalElements,
+        )
     }
 
     private companion object {


### PR DESCRIPTION
Summary
Implements search functionality for opinion lists by name with pagination and privacy controls. Fixes critical bug where search returned hardcoded test data instead of actual results.

Solution
Implemented complete search stack:

Repository: Added findByNameContainingIgnoreCase() for case-insensitive search
Service: Added searchOpinionListsByName() with privacy filtering and pagination
Facade: Added search method with DTO conversion
Controller: Replaced stub with real implementation, fixed getMine()

Verification Scenarios
1. Basic Search
GET /api/opinion-lists/search?nameSubstring=Coffee&page=0&size=10
✅ Returns lists matching "Coffee" with pagination

2. Non-Matching Search
GET /api/opinion-lists/search?nameSubstring=sdsfhlshfla
✅ Returns empty results 

3. Case-Insensitive Search
GET /api/opinion-lists/search?nameSubstring=coffee
GET /api/opinion-lists/search?nameSubstring=COFFEE
✅ Both return same results

4. Privacy Filtering
✅ Owner sees their PRIVATE lists
✅ Non-owners only see SEARCHABLE lists
✅ PRIVATE lists hidden from non-owners

5. Pagination
GET /api/opinion-lists/search?nameSubstring=test&page=0&size=10
GET /api/opinion-lists/search?nameSubstring=test&page=1&size=10
✅ Proper pagination with correct page boundaries

6. My Lists
GET /api/opinion-lists/mine?page=0&size=10
✅ Returns only current user's lists as summary DTOs

7. Frontend Integration
✅ Search works on Discover page
✅ Empty state for non-matching queries
✅ Results appear after 2+ characters

Known Limitations
Opinion count and granted access count set to 0 (TODOs)
Only search by list name implemented
Location/theme/rating filtering not implemented (out of scope)