### PR TITLE
93 moderator side approval functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ frontend_npx() { if command -v nvm >/dev/null 2>&1; then nvm exec $(FRONTEND_NOD
     docker-down docker-logs clean-artifacts ensure-log-dirs clean-logs \
     get-token refresh-token logout routed-request-opinion routed-request-mock routed-request-user-profile routed-request-gdpr routed-request-messaging-threads direct-request-opinion direct-request-mock \
     direct-request-swagger public-request-user routed-request-opinion-approved routed-request-opinion-forbidden routed-request-opinion-mine \
+    routed-request-moderation-approve-flow routed-request-moderation-reject-flow routed-request-moderation-decisions \
     docker-database-create-data-folder docker-database-drop-volume-personal docker-database-drop-volume-campus docker-database-run docker-database-connect \
     build-opinions who-ate-all-the-space clean-the-fuck-out-of-this-campus-machine \
     frontend-install frontend-install-all frontend-check-node frontend-dev frontend-build frontend-lint \
@@ -314,6 +315,165 @@ logout: ## Logout and clear cookies (ENV=local|docker)
 		-H "X-XSRF-TOKEN: $$csrf_token" -i; \
 	rm -f .access_token .cookies; \
 	echo "Logged out and local session files removed."
+
+# Temporary reviewer helpers for issue #93. Remove once subject/opinion creation and moderation
+# can be verified fully through the normal frontend flow.
+routed-request-moderation-approve-flow: ## Temporary full moderation approve smoke flow (ENV=local|docker)
+	@if [ "$(ENV)" = "docker" ]; then \
+		$(LOAD_DOCKER_ENV) \
+		protocol=https; host=localhost; port=8080; \
+	else \
+		$(LOAD_LOCAL_ENV) \
+		protocol=$${INTERSERVICE_PROTOCOL:-http}; host=$${GATEWAY_HOST:-localhost}; port=$${GATEWAY_PORT:-8080}; \
+	fi; \
+	set -e; \
+	curl_args="-s"; \
+	if [ "$$protocol" = "https" ]; then curl_args="$$curl_args -k"; fi; \
+	api="$$protocol://$$host:$$port"; \
+	login() { \
+		email="$$1"; \
+		cookie_file="$$(mktemp)"; \
+		csrf_headers=$$(curl $$curl_args -c "$$cookie_file" -i "$$api/api/auth/csrf" | tr -d '\r'); \
+		csrf_token=$$(printf "%s" "$$csrf_headers" | sed -n 's/.*XSRF-TOKEN=\([^;]*\).*/\1/p' | head -n1); \
+		token=$$(curl $$curl_args -b "$$cookie_file" -c "$$cookie_file" -X POST "$$api/api/auth/login" \
+			-H "Content-Type: application/json" \
+			-H "X-XSRF-TOKEN: $$csrf_token" \
+			-d "{\"login\":\"$$email\",\"password\":\"1234\"}" \
+			| sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p'); \
+		rm -f "$$cookie_file"; \
+		printf "%s" "$$token"; \
+	}; \
+	json_id() { sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -n1; }; \
+	owner_token=$$(login anna@r8n.test); \
+	moderator_token=$$(login lena@r8n.test); \
+	if [ -z "$$owner_token" ] || [ -z "$$moderator_token" ]; then echo "Failed to log in seeded owner/moderator users"; exit 1; fi; \
+	echo "Creating subject..."; \
+	subject_json=$$(curl $$curl_args -X POST "$$api/api/subjects" \
+		-H "Authorization: Bearer $$owner_token" \
+		-H "Content-Type: application/json" \
+		-d '{"name":"Moderation Approve Cafe","referentName":"Moderation Approve Cafe Berlin","address":"Teststrasse 1, Berlin","latitude":52.52,"longitude":13.405}'); \
+	subject_id=$$(printf "%s" "$$subject_json" | json_id); \
+	echo "$$subject_json"; \
+	if [ -z "$$subject_id" ]; then echo "Subject creation failed"; exit 1; fi; \
+	echo "Creating draft opinion..."; \
+	opinion_json=$$(curl $$curl_args -X POST "$$api/api/opinions" \
+		-H "Authorization: Bearer $$owner_token" \
+		--data-urlencode "subjectId=$$subject_id" \
+		--data-urlencode "mark=4.5" \
+		--data-urlencode "subjective=Good coffee, calm room" \
+		--data-urlencode "objective=Paid 4.20 EUR for espresso"); \
+	opinion_id=$$(printf "%s" "$$opinion_json" | json_id); \
+	echo "$$opinion_json"; \
+	if [ -z "$$opinion_id" ]; then echo "Opinion creation failed"; exit 1; fi; \
+	echo "Submitting opinion for moderation..."; \
+	submit_json=$$(curl $$curl_args -X POST "$$api/api/opinions/$$opinion_id/submit-for-moderation" -H "Authorization: Bearer $$owner_token"); \
+	echo "$$submit_json"; \
+	printf "%s" "$$submit_json" | grep -q '"status":"PENDING_PREMODERATION"'; \
+	echo "Checking moderator queue contains the opinion..."; \
+	queue_json=$$(curl $$curl_args "$$api/api/opinions/moderation?page=0&size=20&status=PENDING_PREMODERATION" -H "Authorization: Bearer $$moderator_token"); \
+	echo "$$queue_json"; \
+	printf "%s" "$$queue_json" | grep -q "$$opinion_id"; \
+	echo "Approving opinion..."; \
+	approve_json=$$(curl $$curl_args -X POST "$$api/api/opinions/$$opinion_id/approve" -H "Authorization: Bearer $$moderator_token"); \
+	echo "$$approve_json"; \
+	printf "%s" "$$approve_json" | grep -q '"status":"PUBLISHED"'; \
+	echo "Checking persisted moderation decision..."; \
+	decisions_json=$$(curl $$curl_args "$$api/api/opinions/moderation/decisions?page=0&size=20" -H "Authorization: Bearer $$moderator_token"); \
+	echo "$$decisions_json"; \
+	printf "%s" "$$decisions_json" | grep -q "$$opinion_id"; \
+	printf "%s" "$$decisions_json" | grep -q '"action":"APPROVED"'; \
+	echo "Approve moderation flow passed."
+
+routed-request-moderation-reject-flow: ## Temporary full moderation reject smoke flow (ENV=local|docker)
+	@if [ "$(ENV)" = "docker" ]; then \
+		$(LOAD_DOCKER_ENV) \
+		protocol=https; host=localhost; port=8080; \
+	else \
+		$(LOAD_LOCAL_ENV) \
+		protocol=$${INTERSERVICE_PROTOCOL:-http}; host=$${GATEWAY_HOST:-localhost}; port=$${GATEWAY_PORT:-8080}; \
+	fi; \
+	set -e; \
+	curl_args="-s"; \
+	if [ "$$protocol" = "https" ]; then curl_args="$$curl_args -k"; fi; \
+	api="$$protocol://$$host:$$port"; \
+	login() { \
+		email="$$1"; \
+		cookie_file="$$(mktemp)"; \
+		csrf_headers=$$(curl $$curl_args -c "$$cookie_file" -i "$$api/api/auth/csrf" | tr -d '\r'); \
+		csrf_token=$$(printf "%s" "$$csrf_headers" | sed -n 's/.*XSRF-TOKEN=\([^;]*\).*/\1/p' | head -n1); \
+		token=$$(curl $$curl_args -b "$$cookie_file" -c "$$cookie_file" -X POST "$$api/api/auth/login" \
+			-H "Content-Type: application/json" \
+			-H "X-XSRF-TOKEN: $$csrf_token" \
+			-d "{\"login\":\"$$email\",\"password\":\"1234\"}" \
+			| sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p'); \
+		rm -f "$$cookie_file"; \
+		printf "%s" "$$token"; \
+	}; \
+	json_id() { sed -n 's/.*"id":"\([^"]*\)".*/\1/p' | head -n1; }; \
+	owner_token=$$(login anna@r8n.test); \
+	moderator_token=$$(login lena@r8n.test); \
+	if [ -z "$$owner_token" ] || [ -z "$$moderator_token" ]; then echo "Failed to log in seeded owner/moderator users"; exit 1; fi; \
+	echo "Creating subject..."; \
+	subject_json=$$(curl $$curl_args -X POST "$$api/api/subjects" \
+		-H "Authorization: Bearer $$owner_token" \
+		-H "Content-Type: application/json" \
+		-d '{"name":"Moderation Reject Cafe","referentName":"Moderation Reject Cafe Berlin","address":"Teststrasse 2, Berlin","latitude":52.51,"longitude":13.4}'); \
+	subject_id=$$(printf "%s" "$$subject_json" | json_id); \
+	echo "$$subject_json"; \
+	if [ -z "$$subject_id" ]; then echo "Subject creation failed"; exit 1; fi; \
+	echo "Creating draft opinion..."; \
+	opinion_json=$$(curl $$curl_args -X POST "$$api/api/opinions" \
+		-H "Authorization: Bearer $$owner_token" \
+		--data-urlencode "subjectId=$$subject_id" \
+		--data-urlencode "mark=2.0" \
+		--data-urlencode "subjective=Needs checking before publishing" \
+		--data-urlencode "objective=Contains a claim that should be supported"); \
+	opinion_id=$$(printf "%s" "$$opinion_json" | json_id); \
+	echo "$$opinion_json"; \
+	if [ -z "$$opinion_id" ]; then echo "Opinion creation failed"; exit 1; fi; \
+	echo "Submitting opinion for moderation..."; \
+	submit_json=$$(curl $$curl_args -X POST "$$api/api/opinions/$$opinion_id/submit-for-moderation" -H "Authorization: Bearer $$owner_token"); \
+	echo "$$submit_json"; \
+	printf "%s" "$$submit_json" | grep -q '"status":"PENDING_PREMODERATION"'; \
+	echo "Rejecting opinion..."; \
+	reject_json=$$(curl $$curl_args -X POST "$$api/api/opinions/$$opinion_id/reject" \
+		-H "Authorization: Bearer $$moderator_token" \
+		-H "Content-Type: application/json" \
+		-d '{"reason":"Please add factual support and remove unverifiable claims."}'); \
+	echo "$$reject_json"; \
+	printf "%s" "$$reject_json" | grep -q '"status":"REJECTED"'; \
+	echo "Checking persisted moderation decision..."; \
+	decisions_json=$$(curl $$curl_args "$$api/api/opinions/moderation/decisions?page=0&size=20" -H "Authorization: Bearer $$moderator_token"); \
+	echo "$$decisions_json"; \
+	printf "%s" "$$decisions_json" | grep -q "$$opinion_id"; \
+	printf "%s" "$$decisions_json" | grep -q '"action":"REJECTED"'; \
+	printf "%s" "$$decisions_json" | grep -q 'Please add factual support'; \
+	echo "Reject moderation flow passed."
+
+routed-request-moderation-decisions: ## Temporary request for persisted moderation decisions (ENV=local|docker)
+	@if [ "$(ENV)" = "docker" ]; then \
+		$(LOAD_DOCKER_ENV) \
+		protocol=https; host=localhost; port=8080; \
+	else \
+		$(LOAD_LOCAL_ENV) \
+		protocol=$${INTERSERVICE_PROTOCOL:-http}; host=$${GATEWAY_HOST:-localhost}; port=$${GATEWAY_PORT:-8080}; \
+	fi; \
+	set -e; \
+	curl_args="-s"; \
+	if [ "$$protocol" = "https" ]; then curl_args="$$curl_args -k"; fi; \
+	api="$$protocol://$$host:$$port"; \
+	cookie_file="$$(mktemp)"; \
+	csrf_headers=$$(curl $$curl_args -c "$$cookie_file" -i "$$api/api/auth/csrf" | tr -d '\r'); \
+	csrf_token=$$(printf "%s" "$$csrf_headers" | sed -n 's/.*XSRF-TOKEN=\([^;]*\).*/\1/p' | head -n1); \
+	token=$$(curl $$curl_args -b "$$cookie_file" -c "$$cookie_file" -X POST "$$api/api/auth/login" \
+		-H "Content-Type: application/json" \
+		-H "X-XSRF-TOKEN: $$csrf_token" \
+		-d '{"login":"lena@r8n.test","password":"1234"}' \
+		| sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p'); \
+	rm -f "$$cookie_file"; \
+	if [ -z "$$token" ]; then echo "Failed to log in seeded moderator user"; exit 1; fi; \
+	curl $$curl_args "$$api/api/opinions/moderation/decisions?page=0&size=20" -H "Authorization: Bearer $$token"; \
+	echo
 
 routed-request-opinion-forbidden: ## failing gateway request to opinions (ENV=local|docker)
 	@if [ ! -f .access_token ]; then $(MAKE) get-token ENV=$(ENV); fi

--- a/Makefile
+++ b/Makefile
@@ -370,7 +370,7 @@ routed-request-moderation-approve-flow: ## Temporary full moderation approve smo
 	echo "$$submit_json"; \
 	printf "%s" "$$submit_json" | grep -q '"status":"PENDING_PREMODERATION"'; \
 	echo "Checking moderator queue contains the opinion..."; \
-	queue_json=$$(curl $$curl_args "$$api/api/opinions/moderation?page=0&size=20&status=PENDING_PREMODERATION" -H "Authorization: Bearer $$moderator_token"); \
+	queue_json=$$(curl $$curl_args "$$api/api/opinions/moderation?page=0&size=20" -H "Authorization: Bearer $$moderator_token"); \
 	echo "$$queue_json"; \
 	printf "%s" "$$queue_json" | grep -q "$$opinion_id"; \
 	echo "Approving opinion..."; \

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
@@ -1,11 +1,17 @@
 package com.r8n.backend.opinions.api.opinions
 
+import com.r8n.backend.core.api.PageRequestDto
+import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
+import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
+import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
@@ -18,6 +24,9 @@ interface OpinionsApi {
         const val UPDATE_PATH = "$ROOT_PATH/{opinionId}"
         const val DELETE_PATH = "$ROOT_PATH/{opinionId}"
         const val SUBMIT_FOR_MODERATION_PATH = "$ROOT_PATH/{opinionId}/submit-for-moderation"
+        const val MODERATION_PATH = "$ROOT_PATH/moderation"
+        const val APPROVE_PATH = "$ROOT_PATH/{opinionId}/approve"
+        const val REJECT_PATH = "$ROOT_PATH/{opinionId}/reject"
         const val LINK_PATH = "$ROOT_PATH/link"
         const val UNLINK_PATH = "$ROOT_PATH/unlink/{linkId}"
         const val ADJUST_WEIGHT_PATH = "$ROOT_PATH/adjust-weight/{linkId}"
@@ -64,6 +73,27 @@ interface OpinionsApi {
     @PostMapping(SUBMIT_FOR_MODERATION_PATH)
     fun submitOpinionForModeration(
         @PathVariable opinionId: UUID,
+    ): OpinionDto
+
+    @GetMapping(MODERATION_PATH)
+    fun getModerationOpinions(
+        @RequestParam(required = false)
+        status: OpinionStatusEnumDto?,
+        @Valid
+        pageable: PageRequestDto,
+    ): PageResponseDto<OpinionDto>
+
+    @PostMapping(APPROVE_PATH)
+    fun approveOpinion(
+        @PathVariable opinionId: UUID,
+    ): OpinionDto
+
+    @PostMapping(REJECT_PATH)
+    fun rejectOpinion(
+        @PathVariable opinionId: UUID,
+        @Valid
+        @RequestBody
+        request: RejectOpinionRequestDto,
     ): OpinionDto
 
     @PostMapping(LINK_PATH)

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
@@ -17,6 +17,7 @@ interface OpinionsApi {
         const val CREATE_PATH = ROOT_PATH
         const val UPDATE_PATH = "$ROOT_PATH/{opinionId}"
         const val DELETE_PATH = "$ROOT_PATH/{opinionId}"
+        const val SUBMIT_FOR_MODERATION_PATH = "$ROOT_PATH/{opinionId}/submit-for-moderation"
         const val LINK_PATH = "$ROOT_PATH/link"
         const val UNLINK_PATH = "$ROOT_PATH/unlink/{linkId}"
         const val ADJUST_WEIGHT_PATH = "$ROOT_PATH/adjust-weight/{linkId}"
@@ -59,6 +60,11 @@ interface OpinionsApi {
     fun deleteOpinion(
         @PathVariable opinionId: UUID,
     )
+
+    @PostMapping(SUBMIT_FOR_MODERATION_PATH)
+    fun submitOpinionForModeration(
+        @PathVariable opinionId: UUID,
+    ): OpinionDto
 
     @PostMapping(LINK_PATH)
     fun linkComponent(

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
@@ -4,7 +4,6 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
-import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -79,8 +78,6 @@ interface OpinionsApi {
 
     @GetMapping(MODERATION_PATH)
     fun getModerationOpinions(
-        @RequestParam(required = false)
-        status: OpinionStatusEnumDto?,
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<OpinionDto>

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
@@ -2,6 +2,7 @@ package com.r8n.backend.opinions.api.opinions
 
 import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
@@ -25,6 +26,7 @@ interface OpinionsApi {
         const val DELETE_PATH = "$ROOT_PATH/{opinionId}"
         const val SUBMIT_FOR_MODERATION_PATH = "$ROOT_PATH/{opinionId}/submit-for-moderation"
         const val MODERATION_PATH = "$ROOT_PATH/moderation"
+        const val MODERATION_DECISIONS_PATH = "$ROOT_PATH/moderation/decisions"
         const val APPROVE_PATH = "$ROOT_PATH/{opinionId}/approve"
         const val REJECT_PATH = "$ROOT_PATH/{opinionId}/reject"
         const val LINK_PATH = "$ROOT_PATH/link"
@@ -82,6 +84,12 @@ interface OpinionsApi {
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<OpinionDto>
+
+    @GetMapping(MODERATION_DECISIONS_PATH)
+    fun getModerationDecisions(
+        @Valid
+        pageable: PageRequestDto,
+    ): PageResponseDto<ModerationDecisionDto>
 
     @PostMapping(APPROVE_PATH)
     fun approveOpinion(

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/ModerationDecisionActionDto.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/ModerationDecisionActionDto.kt
@@ -1,0 +1,6 @@
+package com.r8n.backend.opinions.api.opinions.dto
+
+enum class ModerationDecisionActionDto {
+    APPROVED,
+    REJECTED,
+}

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/ModerationDecisionDto.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/ModerationDecisionDto.kt
@@ -1,0 +1,18 @@
+package com.r8n.backend.opinions.api.opinions.dto
+
+import java.time.Instant
+import java.util.UUID
+
+data class ModerationDecisionDto(
+    val id: UUID,
+    val opinionId: UUID,
+    val subjectName: String,
+    val ownerName: String,
+    val moderatorId: UUID,
+    val moderatorName: String,
+    val action: ModerationDecisionActionDto,
+    val previousStatus: OpinionStatusEnumDto,
+    val newStatus: OpinionStatusEnumDto,
+    val reason: String?,
+    val createdAt: Instant,
+)

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/RejectOpinionRequestDto.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/dto/RejectOpinionRequestDto.kt
@@ -1,0 +1,12 @@
+package com.r8n.backend.opinions.api.opinions.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+const val REJECTION_REASON_MAX_LENGTH = 2000
+
+data class RejectOpinionRequestDto(
+    @field:NotBlank
+    @field:Size(max = REJECTION_REASON_MAX_LENGTH)
+    val reason: String,
+)

--- a/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
+++ b/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
@@ -10,11 +10,13 @@ import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.DELETE_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_BY_ID_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_FOR_SUBJECT_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.LINK_PATH
+import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.MODERATION_DECISIONS_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.MODERATION_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.REJECT_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.SUBMIT_FOR_MODERATION_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UNLINK_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UPDATE_PATH
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
@@ -113,6 +115,22 @@ class OpinionsRestClient(
                     }.build()
             }.retrieve()
             .body<PageResponseDto<OpinionDto>>()!!
+
+    override fun getModerationDecisions(pageable: PageRequestDto): PageResponseDto<ModerationDecisionDto> =
+        restClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path(MODERATION_DECISIONS_PATH)
+                    .queryParam("page", pageable.page)
+                    .queryParam("size", pageable.size)
+                    .apply {
+                        pageable.sort.forEach {
+                            queryParam("sort", "${it.property},${it.direction}")
+                        }
+                    }.build()
+            }.retrieve()
+            .body<PageResponseDto<ModerationDecisionDto>>()!!
 
     override fun approveOpinion(opinionId: UUID): OpinionDto =
         restClient

--- a/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
+++ b/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
@@ -18,11 +18,9 @@ import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UNLINK_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UPDATE_PATH
 import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
-import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
-import java.util.Optional
 import java.util.UUID
 
 class OpinionsRestClient(
@@ -96,16 +94,12 @@ class OpinionsRestClient(
             .retrieve()
             .body<OpinionDto>()!!
 
-    override fun getModerationOpinions(
-        status: OpinionStatusEnumDto?,
-        pageable: PageRequestDto,
-    ): PageResponseDto<OpinionDto> =
+    override fun getModerationOpinions(pageable: PageRequestDto): PageResponseDto<OpinionDto> =
         restClient
             .get()
             .uri { uriBuilder ->
                 uriBuilder
                     .path(MODERATION_PATH)
-                    .queryParamIfPresent("status", Optional.ofNullable(status))
                     .queryParam("page", pageable.page)
                     .queryParam("size", pageable.size)
                     .apply {

--- a/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
+++ b/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
@@ -7,6 +7,7 @@ import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.DELETE_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_BY_ID_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_FOR_SUBJECT_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.LINK_PATH
+import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.SUBMIT_FOR_MODERATION_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UNLINK_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UPDATE_PATH
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
@@ -77,6 +78,13 @@ class OpinionsRestClient(
             .retrieve()
             .toBodilessEntity()
     }
+
+    override fun submitOpinionForModeration(opinionId: UUID): OpinionDto =
+        restClient
+            .post()
+            .uri(SUBMIT_FOR_MODERATION_PATH, opinionId)
+            .retrieve()
+            .body<OpinionDto>()!!
 
     override fun linkComponent(
         parentOpinionId: UUID,

--- a/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
+++ b/backend/opinions-sv/client/src/main/kotlin/com/r8n/backend/opinions/integration/client/OpinionsRestClient.kt
@@ -1,18 +1,26 @@
 package com.r8n.backend.opinions.integration.client
 
+import com.r8n.backend.core.api.PageRequestDto
+import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.OpinionsApi
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.ADJUST_WEIGHT_PATH
+import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.APPROVE_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.CREATE_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.DELETE_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_BY_ID_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.GET_FOR_SUBJECT_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.LINK_PATH
+import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.MODERATION_PATH
+import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.REJECT_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.SUBMIT_FOR_MODERATION_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UNLINK_PATH
 import com.r8n.backend.opinions.api.opinions.OpinionsApi.Companion.UPDATE_PATH
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
+import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
+import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import org.springframework.web.client.RestClient
 import org.springframework.web.client.body
+import java.util.Optional
 import java.util.UUID
 
 class OpinionsRestClient(
@@ -83,6 +91,44 @@ class OpinionsRestClient(
         restClient
             .post()
             .uri(SUBMIT_FOR_MODERATION_PATH, opinionId)
+            .retrieve()
+            .body<OpinionDto>()!!
+
+    override fun getModerationOpinions(
+        status: OpinionStatusEnumDto?,
+        pageable: PageRequestDto,
+    ): PageResponseDto<OpinionDto> =
+        restClient
+            .get()
+            .uri { uriBuilder ->
+                uriBuilder
+                    .path(MODERATION_PATH)
+                    .queryParamIfPresent("status", Optional.ofNullable(status))
+                    .queryParam("page", pageable.page)
+                    .queryParam("size", pageable.size)
+                    .apply {
+                        pageable.sort.forEach {
+                            queryParam("sort", "${it.property},${it.direction}")
+                        }
+                    }.build()
+            }.retrieve()
+            .body<PageResponseDto<OpinionDto>>()!!
+
+    override fun approveOpinion(opinionId: UUID): OpinionDto =
+        restClient
+            .post()
+            .uri(APPROVE_PATH, opinionId)
+            .retrieve()
+            .body<OpinionDto>()!!
+
+    override fun rejectOpinion(
+        opinionId: UUID,
+        request: RejectOpinionRequestDto,
+    ): OpinionDto =
+        restClient
+            .post()
+            .uri(REJECT_PATH, opinionId)
+            .body(request)
             .retrieve()
             .body<OpinionDto>()!!
 

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -6,8 +6,10 @@ import com.r8n.backend.opinions.opinions.facade.OpinionFacade
 import com.r8n.backend.security.Authority.IS_USER
 import com.r8n.backend.security.Authority.IS_USER_OR_SERVICE
 import com.r8n.backend.security.CurrentUserIdentifier.getCurrentUserId
+import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 @RestController
@@ -40,6 +42,10 @@ class OpinionsController(
     override fun deleteOpinion(opinionId: UUID) {
         opinionFacade.deleteOpinion(opinionId, getCurrentUserId())
     }
+
+    @PreAuthorize(IS_USER)
+    override fun submitOpinionForModeration(opinionId: UUID): OpinionDto =
+        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion submission is not implemented yet")
 
     @PreAuthorize(IS_USER)
     override fun linkComponent(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -4,7 +4,6 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.OpinionsApi
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
-import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import com.r8n.backend.opinions.opinions.facade.OpinionFacade
 import com.r8n.backend.security.Authority.IS_MODERATOR
@@ -51,10 +50,8 @@ class OpinionsController(
         opinionFacade.submitOpinionForModeration(opinionId, getCurrentUserId())
 
     @PreAuthorize(IS_MODERATOR)
-    override fun getModerationOpinions(
-        status: OpinionStatusEnumDto?,
-        pageable: PageRequestDto,
-    ): PageResponseDto<OpinionDto> = opinionFacade.getModerationOpinions(status, pageable)
+    override fun getModerationOpinions(pageable: PageRequestDto): PageResponseDto<OpinionDto> =
+        opinionFacade.getModerationOpinions(pageable)
 
     @PreAuthorize(IS_MODERATOR)
     override fun getModerationDecisions(pageable: PageRequestDto) = opinionFacade.getModerationDecisions(pageable)

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -57,13 +57,17 @@ class OpinionsController(
     ): PageResponseDto<OpinionDto> = opinionFacade.getModerationOpinions(status, pageable)
 
     @PreAuthorize(IS_MODERATOR)
-    override fun approveOpinion(opinionId: UUID): OpinionDto = opinionFacade.approveOpinion(opinionId)
+    override fun getModerationDecisions(pageable: PageRequestDto) = opinionFacade.getModerationDecisions(pageable)
+
+    @PreAuthorize(IS_MODERATOR)
+    override fun approveOpinion(opinionId: UUID): OpinionDto =
+        opinionFacade.approveOpinion(opinionId, getCurrentUserId())
 
     @PreAuthorize(IS_MODERATOR)
     override fun rejectOpinion(
         opinionId: UUID,
         request: RejectOpinionRequestDto,
-    ): OpinionDto = opinionFacade.rejectOpinion(opinionId, request.reason)
+    ): OpinionDto = opinionFacade.rejectOpinion(opinionId, getCurrentUserId(), request.reason)
 
     @PreAuthorize(IS_USER)
     override fun linkComponent(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -1,13 +1,20 @@
 package com.r8n.backend.opinions.opinions.controller
 
+import com.r8n.backend.core.api.PageRequestDto
+import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.OpinionsApi
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
+import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
+import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import com.r8n.backend.opinions.opinions.facade.OpinionFacade
+import com.r8n.backend.security.Authority.IS_MODERATOR
 import com.r8n.backend.security.Authority.IS_USER
 import com.r8n.backend.security.Authority.IS_USER_OR_SERVICE
 import com.r8n.backend.security.CurrentUserIdentifier.getCurrentUserId
+import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 @RestController
@@ -44,6 +51,24 @@ class OpinionsController(
     @PreAuthorize(IS_USER)
     override fun submitOpinionForModeration(opinionId: UUID): OpinionDto =
         opinionFacade.submitOpinionForModeration(opinionId, getCurrentUserId())
+
+    @PreAuthorize(IS_MODERATOR)
+    override fun getModerationOpinions(
+        status: OpinionStatusEnumDto?,
+        pageable: PageRequestDto,
+    ): PageResponseDto<OpinionDto> =
+        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion moderation queue is not implemented yet")
+
+    @PreAuthorize(IS_MODERATOR)
+    override fun approveOpinion(opinionId: UUID): OpinionDto =
+        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion approval is not implemented yet")
+
+    @PreAuthorize(IS_MODERATOR)
+    override fun rejectOpinion(
+        opinionId: UUID,
+        request: RejectOpinionRequestDto,
+    ): OpinionDto =
+        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion rejection is not implemented yet")
 
     @PreAuthorize(IS_USER)
     override fun linkComponent(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -6,10 +6,8 @@ import com.r8n.backend.opinions.opinions.facade.OpinionFacade
 import com.r8n.backend.security.Authority.IS_USER
 import com.r8n.backend.security.Authority.IS_USER_OR_SERVICE
 import com.r8n.backend.security.CurrentUserIdentifier.getCurrentUserId
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 @RestController
@@ -45,7 +43,7 @@ class OpinionsController(
 
     @PreAuthorize(IS_USER)
     override fun submitOpinionForModeration(opinionId: UUID): OpinionDto =
-        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion submission is not implemented yet")
+        opinionFacade.submitOpinionForModeration(opinionId, getCurrentUserId())
 
     @PreAuthorize(IS_USER)
     override fun linkComponent(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/controller/OpinionsController.kt
@@ -11,10 +11,8 @@ import com.r8n.backend.security.Authority.IS_MODERATOR
 import com.r8n.backend.security.Authority.IS_USER
 import com.r8n.backend.security.Authority.IS_USER_OR_SERVICE
 import com.r8n.backend.security.CurrentUserIdentifier.getCurrentUserId
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.server.ResponseStatusException
 import java.util.UUID
 
 @RestController
@@ -56,19 +54,16 @@ class OpinionsController(
     override fun getModerationOpinions(
         status: OpinionStatusEnumDto?,
         pageable: PageRequestDto,
-    ): PageResponseDto<OpinionDto> =
-        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion moderation queue is not implemented yet")
+    ): PageResponseDto<OpinionDto> = opinionFacade.getModerationOpinions(status, pageable)
 
     @PreAuthorize(IS_MODERATOR)
-    override fun approveOpinion(opinionId: UUID): OpinionDto =
-        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion approval is not implemented yet")
+    override fun approveOpinion(opinionId: UUID): OpinionDto = opinionFacade.approveOpinion(opinionId)
 
     @PreAuthorize(IS_MODERATOR)
     override fun rejectOpinion(
         opinionId: UUID,
         request: RejectOpinionRequestDto,
-    ): OpinionDto =
-        throw ResponseStatusException(HttpStatus.NOT_IMPLEMENTED, "Opinion rejection is not implemented yet")
+    ): OpinionDto = opinionFacade.rejectOpinion(opinionId, request.reason)
 
     @PreAuthorize(IS_USER)
     override fun linkComponent(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/database/ModerationDecisionRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/database/ModerationDecisionRepository.kt
@@ -1,0 +1,11 @@
+package com.r8n.backend.opinions.opinions.database
+
+import com.r8n.backend.opinions.opinions.persistence.ModerationDecisionPersistence
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ModerationDecisionRepository : JpaRepository<ModerationDecisionPersistence, UUID> {
+    fun findAllByOrderByCreatedAtDesc(pageable: Pageable): Page<ModerationDecisionPersistence>
+}

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/database/OpinionRepository.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/database/OpinionRepository.kt
@@ -1,10 +1,18 @@
 package com.r8n.backend.opinions.opinions.database
 
+import com.r8n.backend.opinions.opinions.domain.OpinionStatusEnum
 import com.r8n.backend.opinions.opinions.persistence.OpinionPersistence
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
 interface OpinionRepository : JpaRepository<OpinionPersistence, UUID> {
+    fun findAllByStatus(
+        status: OpinionStatusEnum,
+        pageable: Pageable,
+    ): Page<OpinionPersistence>
+
     fun findFirstBySubjectAndOwnerOrderByTimestampDesc(
         subject: UUID,
         owner: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/domain/ModerationDecision.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/domain/ModerationDecision.kt
@@ -1,0 +1,17 @@
+package com.r8n.backend.opinions.opinions.domain
+
+import java.time.Instant
+import java.util.UUID
+
+data class ModerationDecision(
+    val id: UUID,
+    val opinionId: UUID,
+    val subjectName: String,
+    val owner: UUID,
+    val moderator: UUID,
+    val action: ModerationDecisionAction,
+    val previousStatus: OpinionStatusEnum,
+    val newStatus: OpinionStatusEnum,
+    val reason: String?,
+    val createdAt: Instant,
+)

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/domain/ModerationDecisionAction.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/domain/ModerationDecisionAction.kt
@@ -1,0 +1,6 @@
+package com.r8n.backend.opinions.opinions.domain
+
+enum class ModerationDecisionAction {
+    APPROVED,
+    REJECTED,
+}

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
@@ -4,6 +4,7 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.core.utils.toPageable
 import com.r8n.backend.core.utils.toResponse
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.opinions.service.OpinionService
@@ -64,12 +65,22 @@ class OpinionFacade(
             ).map { opinionMapper.toDto(it) }
             .toResponse()
 
-    fun approveOpinion(opinionId: UUID): OpinionDto = opinionMapper.toDto(opinionService.approveOpinion(opinionId))
+    fun getModerationDecisions(pageable: PageRequestDto): PageResponseDto<ModerationDecisionDto> =
+        opinionService
+            .getModerationDecisions(pageable.toPageable())
+            .map { opinionMapper.toDto(it) }
+            .toResponse()
+
+    fun approveOpinion(
+        opinionId: UUID,
+        moderatorId: UUID,
+    ): OpinionDto = opinionMapper.toDto(opinionService.approveOpinion(opinionId, moderatorId))
 
     fun rejectOpinion(
         opinionId: UUID,
+        moderatorId: UUID,
         reason: String,
-    ): OpinionDto = opinionMapper.toDto(opinionService.rejectOpinion(opinionId, reason))
+    ): OpinionDto = opinionMapper.toDto(opinionService.rejectOpinion(opinionId, moderatorId, reason))
 
     fun linkComponent(
         parentOpinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
@@ -6,7 +6,6 @@ import com.r8n.backend.core.utils.toPageable
 import com.r8n.backend.core.utils.toResponse
 import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
-import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.opinions.service.OpinionService
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -54,15 +53,10 @@ class OpinionFacade(
         ownerId: UUID,
     ): OpinionDto = opinionMapper.toDto(opinionService.submitOpinionForModeration(opinionId, ownerId))
 
-    fun getModerationOpinions(
-        status: OpinionStatusEnumDto?,
-        pageable: PageRequestDto,
-    ): PageResponseDto<OpinionDto> =
+    fun getModerationOpinions(pageable: PageRequestDto): PageResponseDto<OpinionDto> =
         opinionService
-            .getModerationOpinions(
-                status?.let { with(opinionMapper) { it.fromDto() } },
-                pageable.toPageable(),
-            ).map { opinionMapper.toDto(it) }
+            .getModerationOpinions(pageable.toPageable())
+            .map { opinionMapper.toDto(it) }
             .toResponse()
 
     fun getModerationDecisions(pageable: PageRequestDto): PageResponseDto<ModerationDecisionDto> =

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
@@ -43,6 +43,11 @@ class OpinionFacade(
         opinionService.deleteOpinion(opinionId, ownerId)
     }
 
+    fun submitOpinionForModeration(
+        opinionId: UUID,
+        ownerId: UUID,
+    ): OpinionDto = opinionMapper.toDto(opinionService.submitOpinionForModeration(opinionId, ownerId))
+
     fun linkComponent(
         parentOpinionId: UUID,
         childOpinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionFacade.kt
@@ -1,6 +1,11 @@
 package com.r8n.backend.opinions.opinions.facade
 
+import com.r8n.backend.core.api.PageRequestDto
+import com.r8n.backend.core.api.PageResponseDto
+import com.r8n.backend.core.utils.toPageable
+import com.r8n.backend.core.utils.toResponse
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
+import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.opinions.service.OpinionService
 import org.springframework.stereotype.Component
 import java.util.UUID
@@ -47,6 +52,24 @@ class OpinionFacade(
         opinionId: UUID,
         ownerId: UUID,
     ): OpinionDto = opinionMapper.toDto(opinionService.submitOpinionForModeration(opinionId, ownerId))
+
+    fun getModerationOpinions(
+        status: OpinionStatusEnumDto?,
+        pageable: PageRequestDto,
+    ): PageResponseDto<OpinionDto> =
+        opinionService
+            .getModerationOpinions(
+                status?.let { with(opinionMapper) { it.fromDto() } },
+                pageable.toPageable(),
+            ).map { opinionMapper.toDto(it) }
+            .toResponse()
+
+    fun approveOpinion(opinionId: UUID): OpinionDto = opinionMapper.toDto(opinionService.approveOpinion(opinionId))
+
+    fun rejectOpinion(
+        opinionId: UUID,
+        reason: String,
+    ): OpinionDto = opinionMapper.toDto(opinionService.rejectOpinion(opinionId, reason))
 
     fun linkComponent(
         parentOpinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionMapper.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/facade/OpinionMapper.kt
@@ -1,8 +1,12 @@
 package com.r8n.backend.opinions.opinions.facade
 
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionActionDto
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.WeightedOpinionReferenceDto
+import com.r8n.backend.opinions.opinions.domain.ModerationDecision
+import com.r8n.backend.opinions.opinions.domain.ModerationDecisionAction
 import com.r8n.backend.opinions.opinions.domain.Opinion
 import com.r8n.backend.opinions.opinions.domain.OpinionStatusEnum
 import com.r8n.backend.opinions.opinions.domain.WeightedOpinionReference
@@ -29,6 +33,29 @@ class OpinionMapper(
                 status.toDto(),
                 timestamp,
             )
+        }
+
+    fun toDto(decision: ModerationDecision): ModerationDecisionDto =
+        with(decision) {
+            ModerationDecisionDto(
+                id = id,
+                opinionId = opinionId,
+                subjectName = subjectName,
+                ownerName = usersInternalApi.getUserName(owner),
+                moderatorId = moderator,
+                moderatorName = usersInternalApi.getUserName(moderator),
+                action = action.toDto(),
+                previousStatus = previousStatus.toDto(),
+                newStatus = newStatus.toDto(),
+                reason = reason,
+                createdAt = createdAt,
+            )
+        }
+
+    private fun ModerationDecisionAction.toDto(): ModerationDecisionActionDto =
+        when (this) {
+            ModerationDecisionAction.APPROVED -> ModerationDecisionActionDto.APPROVED
+            ModerationDecisionAction.REJECTED -> ModerationDecisionActionDto.REJECTED
         }
 
     fun OpinionStatusEnum.toDto(): OpinionStatusEnumDto =

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/persistence/ModerationDecisionPersistence.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/persistence/ModerationDecisionPersistence.kt
@@ -1,0 +1,47 @@
+package com.r8n.backend.opinions.opinions.persistence
+
+import com.r8n.backend.opinions.opinions.domain.ModerationDecisionAction
+import com.r8n.backend.opinions.opinions.domain.OpinionStatusEnum
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.UuidGenerator
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(schema = "opinions", name = "moderation_decisions")
+class ModerationDecisionPersistence(
+    @Id
+    @GeneratedValue
+    @UuidGenerator(style = UuidGenerator.Style.VERSION_7)
+    var id: UUID? = null,
+//
+    @Column(nullable = false)
+    var opinion: UUID,
+//
+    @Column(nullable = false)
+    var moderator: UUID,
+//
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var action: ModerationDecisionAction,
+//
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var previousStatus: OpinionStatusEnum,
+//
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var newStatus: OpinionStatusEnum,
+//
+    @Column(nullable = true)
+    var reason: String?,
+//
+    @Column(nullable = false)
+    var createdAt: Instant,
+)

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
@@ -7,6 +7,8 @@ import com.r8n.backend.opinions.opinions.domain.Opinion
 import com.r8n.backend.opinions.opinions.domain.OpinionStatusEnum
 import com.r8n.backend.opinions.opinions.persistence.OpinionPersistence
 import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -127,6 +129,34 @@ class OpinionService(
         return opinionRepository.save(opinion).toDomain()
     }
 
+    @Transactional(readOnly = true)
+    fun getModerationOpinions(
+        status: OpinionStatusEnum?,
+        pageable: Pageable,
+    ): Page<Opinion> {
+        val requestedStatus = status ?: OpinionStatusEnum.PENDING_PREMODERATION
+        if (requestedStatus != OpinionStatusEnum.PENDING_PREMODERATION) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Moderation queue only supports pending opinions")
+        }
+
+        return opinionRepository.findAllByStatus(requestedStatus, pageable).map { it.toDomain() }
+    }
+
+    @Transactional
+    fun approveOpinion(opinionId: UUID): Opinion = transitionPendingOpinion(opinionId, OpinionStatusEnum.PUBLISHED)
+
+    @Transactional
+    fun rejectOpinion(
+        opinionId: UUID,
+        reason: String,
+    ): Opinion {
+        if (reason.trim().isEmpty()) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Rejection reason must not be blank")
+        }
+
+        return transitionPendingOpinion(opinionId, OpinionStatusEnum.REJECTED)
+    }
+
     @Transactional
     fun linkComponent(
         parentOpinionId: UUID,
@@ -198,6 +228,26 @@ class OpinionService(
             throw ResponseStatusException(HttpStatus.NOT_FOUND)
         }
         return getOpinion(parentOpinionId, requesterId)
+    }
+
+    private fun transitionPendingOpinion(
+        opinionId: UUID,
+        targetStatus: OpinionStatusEnum,
+    ): Opinion {
+        val opinion =
+            opinionRepository
+                .findById(opinionId)
+                .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND) }
+        if (opinion.status != OpinionStatusEnum.PENDING_PREMODERATION) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Only opinions pending premoderation can be moderated",
+            )
+        }
+
+        opinion.status = targetStatus
+        opinion.timestamp = Instant.now()
+        return opinionRepository.save(opinion).toDomain()
     }
 
     private fun OpinionPersistence.toDomain(): Opinion =

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
@@ -135,17 +135,8 @@ class OpinionService(
     }
 
     @Transactional(readOnly = true)
-    fun getModerationOpinions(
-        status: OpinionStatusEnum?,
-        pageable: Pageable,
-    ): Page<Opinion> {
-        val requestedStatus = status ?: OpinionStatusEnum.PENDING_PREMODERATION
-        if (requestedStatus != OpinionStatusEnum.PENDING_PREMODERATION) {
-            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Moderation queue only supports pending opinions")
-        }
-
-        return opinionRepository.findAllByStatus(requestedStatus, pageable).map { it.toDomain() }
-    }
+    fun getModerationOpinions(pageable: Pageable): Page<Opinion> =
+        opinionRepository.findAllByStatus(OpinionStatusEnum.PENDING_PREMODERATION, pageable).map { it.toDomain() }
 
     @Transactional
     fun approveOpinion(

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
@@ -106,6 +106,28 @@ class OpinionService(
     }
 
     @Transactional
+    fun submitOpinionForModeration(
+        opinionId: UUID,
+        requesterId: UUID,
+    ): Opinion {
+        val opinion =
+            opinionRepository
+                .findById(
+                    opinionId,
+                ).orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND) }
+        if (opinion.owner != requesterId) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only the opinion owner can submit it for moderation")
+        }
+        if (opinion.status != OpinionStatusEnum.DRAFT) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Only draft opinions can be submitted for moderation")
+        }
+
+        opinion.status = OpinionStatusEnum.PENDING_PREMODERATION
+        opinion.timestamp = Instant.now()
+        return opinionRepository.save(opinion).toDomain()
+    }
+
+    @Transactional
     fun linkComponent(
         parentOpinionId: UUID,
         childOpinionId: UUID,

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/opinions/service/OpinionService.kt
@@ -2,9 +2,13 @@ package com.r8n.backend.opinions.opinions.service
 
 import com.r8n.backend.opinions.access.domain.OpinionPermissionEnum
 import com.r8n.backend.opinions.access.service.AccessService
+import com.r8n.backend.opinions.opinions.database.ModerationDecisionRepository
 import com.r8n.backend.opinions.opinions.database.OpinionRepository
+import com.r8n.backend.opinions.opinions.domain.ModerationDecision
+import com.r8n.backend.opinions.opinions.domain.ModerationDecisionAction
 import com.r8n.backend.opinions.opinions.domain.Opinion
 import com.r8n.backend.opinions.opinions.domain.OpinionStatusEnum
+import com.r8n.backend.opinions.opinions.persistence.ModerationDecisionPersistence
 import com.r8n.backend.opinions.opinions.persistence.OpinionPersistence
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.data.domain.Page
@@ -22,6 +26,7 @@ class OpinionService(
     private val noteService: OpinionNoteService,
     private val componentService: ComponentService,
     private val opinionRepository: OpinionRepository,
+    private val moderationDecisionRepository: ModerationDecisionRepository,
     private val accessService: AccessService,
 ) {
     fun getOpinion(
@@ -143,19 +148,28 @@ class OpinionService(
     }
 
     @Transactional
-    fun approveOpinion(opinionId: UUID): Opinion = transitionPendingOpinion(opinionId, OpinionStatusEnum.PUBLISHED)
+    fun approveOpinion(
+        opinionId: UUID,
+        moderatorId: UUID,
+    ): Opinion = transitionPendingOpinion(opinionId, OpinionStatusEnum.PUBLISHED, moderatorId, null)
 
     @Transactional
     fun rejectOpinion(
         opinionId: UUID,
+        moderatorId: UUID,
         reason: String,
     ): Opinion {
-        if (reason.trim().isEmpty()) {
+        val trimmedReason = reason.trim()
+        if (trimmedReason.isEmpty()) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Rejection reason must not be blank")
         }
 
-        return transitionPendingOpinion(opinionId, OpinionStatusEnum.REJECTED)
+        return transitionPendingOpinion(opinionId, OpinionStatusEnum.REJECTED, moderatorId, trimmedReason)
     }
+
+    @Transactional(readOnly = true)
+    fun getModerationDecisions(pageable: Pageable): Page<ModerationDecision> =
+        moderationDecisionRepository.findAllByOrderByCreatedAtDesc(pageable).map { it.toDomain() }
 
     @Transactional
     fun linkComponent(
@@ -233,6 +247,8 @@ class OpinionService(
     private fun transitionPendingOpinion(
         opinionId: UUID,
         targetStatus: OpinionStatusEnum,
+        moderatorId: UUID,
+        reason: String?,
     ): Opinion {
         val opinion =
             opinionRepository
@@ -245,10 +261,33 @@ class OpinionService(
             )
         }
 
+        val previousStatus = opinion.status
         opinion.status = targetStatus
-        opinion.timestamp = Instant.now()
-        return opinionRepository.save(opinion).toDomain()
+        val decisionTimestamp = Instant.now()
+        opinion.timestamp = decisionTimestamp
+        val savedOpinion = opinionRepository.save(opinion)
+        moderationDecisionRepository.save(
+            ModerationDecisionPersistence(
+                opinion = savedOpinion.id!!,
+                moderator = moderatorId,
+                action = targetStatus.toModerationDecisionAction(),
+                previousStatus = previousStatus,
+                newStatus = targetStatus,
+                reason = reason,
+                createdAt = decisionTimestamp,
+            ),
+        )
+        return savedOpinion.toDomain()
     }
+
+    private fun OpinionStatusEnum.toModerationDecisionAction(): ModerationDecisionAction =
+        when (this) {
+            OpinionStatusEnum.PUBLISHED -> ModerationDecisionAction.APPROVED
+            OpinionStatusEnum.REJECTED -> ModerationDecisionAction.REJECTED
+            OpinionStatusEnum.DRAFT,
+            OpinionStatusEnum.PENDING_PREMODERATION,
+                -> throw IllegalArgumentException("Unsupported moderation decision status: $this")
+        }
 
     private fun OpinionPersistence.toDomain(): Opinion =
         Opinion(
@@ -263,4 +302,25 @@ class OpinionService(
             status,
             timestamp,
         )
+
+    private fun ModerationDecisionPersistence.toDomain(): ModerationDecision {
+        val opinionPersistence =
+            opinionRepository
+                .findById(opinion)
+                .orElseThrow { ResponseStatusException(HttpStatus.NOT_FOUND) }
+        val opinionId = opinionPersistence.id ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+
+        return ModerationDecision(
+            id!!,
+            opinionId,
+            subjectService.getSubjectName(opinionPersistence.subject) ?: "UNNAMED",
+            opinionPersistence.owner,
+            moderator,
+            action,
+            previousStatus,
+            newStatus,
+            reason,
+            createdAt,
+        )
+    }
 }

--- a/backend/opinions-sv/service/src/main/resources/db/changelog/db.changelog-master.sql
+++ b/backend/opinions-sv/service/src/main/resources/db/changelog/db.changelog-master.sql
@@ -444,3 +444,20 @@ VALUES
     ('a0000000-0000-0000-0000-000000000101', '80000000-0000-0000-0000-000000000001', '80000000-0000-0000-0000-000000000000', 0.8), -- Bernard synced to Smoke List
     ('a0000000-0000-0000-0000-000000000102', '80000000-0000-0000-0000-000000000002', '80000000-0000-0000-0000-000000000000', 1.0)  -- Anna synced to Smoke List
 ON CONFLICT (id) DO NOTHING;
+
+--changeset codex:V15_moderation_decisions
+CREATE TABLE IF NOT EXISTS opinions.moderation_decisions (
+    id UUID PRIMARY KEY,
+    opinion UUID NOT NULL,
+    moderator UUID NOT NULL,
+    action VARCHAR(32) NOT NULL,
+    previous_status VARCHAR(32) NOT NULL,
+    new_status VARCHAR(32) NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_moderation_decisions_opinion FOREIGN KEY (opinion) REFERENCES opinions.opinions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_decisions_opinion ON opinions.moderation_decisions(opinion);
+CREATE INDEX IF NOT EXISTS idx_moderation_decisions_moderator ON opinions.moderation_decisions(moderator);
+CREATE INDEX IF NOT EXISTS idx_moderation_decisions_created_at ON opinions.moderation_decisions(created_at);

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -417,7 +417,6 @@ class OpinionsIntegrationTests {
                 .perform(
                     get("/api/opinions/moderation")
                         .with(csrf())
-                        .queryParam("status", "PENDING_PREMODERATION")
                         .queryParam("page", "0")
                         .queryParam("size", "20")
                         .header("Authorization", "Bearer $moderatorToken"),

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -305,6 +305,102 @@ class OpinionsIntegrationTests {
 
     @Test
     @WithMockUser
+    fun `submit opinion for moderation moves owner draft to pending premoderation`() {
+        val accessToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val createResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions")
+                        .with(csrf())
+                        .queryParam("subjectId", "15151515-1515-1515-1515-151515151515")
+                        .queryParam("subjective", "pending subjective")
+                        .queryParam("objective", "pending objective")
+                        .queryParam("mark", "6.30")
+                        .header("Authorization", "Bearer $accessToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val created: OpinionDto = objectMapper.readValue(createResult.response.contentAsString)
+
+        val submitResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions/${created.id}/submit-for-moderation")
+                        .with(csrf())
+                        .header("Authorization", "Bearer $accessToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: OpinionDto = objectMapper.readValue(submitResult.response.contentAsString)
+        assertEquals(created.id, actual.id)
+        assertEquals(REQUESTER, actual.owner)
+        assertEquals(OpinionStatusEnumDto.PENDING_PREMODERATION, actual.status)
+    }
+
+    @Test
+    @WithMockUser
+    fun `submit opinion for moderation rejects non owner`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val otherUserToken = serviceTokenService.generateAccessToken(STRANGER, listOf("USER"))
+        val createResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions")
+                        .with(csrf())
+                        .queryParam("subjectId", "15151515-1515-1515-1515-151515151515")
+                        .queryParam("subjective", "owner only subjective")
+                        .queryParam("objective", "owner only objective")
+                        .queryParam("mark", "7.20")
+                        .header("Authorization", "Bearer $ownerToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val created: OpinionDto = objectMapper.readValue(createResult.response.contentAsString)
+
+        mockMvc
+            .perform(
+                post("/api/opinions/${created.id}/submit-for-moderation")
+                    .with(csrf())
+                    .header("Authorization", "Bearer $otherUserToken"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser
+    fun `submit opinion for moderation rejects non draft opinion`() {
+        val accessToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val createResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions")
+                        .with(csrf())
+                        .queryParam("subjectId", "15151515-1515-1515-1515-151515151515")
+                        .queryParam("subjective", "single submit subjective")
+                        .queryParam("objective", "single submit objective")
+                        .queryParam("mark", "8.10")
+                        .header("Authorization", "Bearer $accessToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val created: OpinionDto = objectMapper.readValue(createResult.response.contentAsString)
+
+        mockMvc
+            .perform(
+                post("/api/opinions/${created.id}/submit-for-moderation")
+                    .with(csrf())
+                    .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isOk)
+
+        mockMvc
+            .perform(
+                post("/api/opinions/${created.id}/submit-for-moderation")
+                    .with(csrf())
+                    .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser
     fun `update opinion works`() {
         val accessToken = serviceTokenService.generateAccessToken(OWNER, listOf("USER"))
         val createResult =

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -4,6 +4,7 @@ import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionSubjectDto
+import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
 import com.r8n.backend.opinions.api.subjects.dto.CreateSubjectRequestDto
 import com.r8n.backend.opinions.api.subjects.dto.SUBJECT_NAME_MAX_LENGTH
 import com.r8n.backend.opinions.stub.OpinionSubjectTestDataFactory.bernardReferent
@@ -396,6 +397,128 @@ class OpinionsIntegrationTests {
                 post("/api/opinions/${created.id}/submit-for-moderation")
                     .with(csrf())
                     .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser
+    fun `moderator can list pending moderation opinions`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val moderatorToken = serviceTokenService.generateAccessToken(STRANGER, listOf("MODERATOR"))
+        val created = createDraftOpinion(ownerToken, "moderation queue subjective")
+        submitForModeration(ownerToken, created.id)
+
+        val result =
+            mockMvc
+                .perform(
+                    get("/api/opinions/moderation")
+                        .with(csrf())
+                        .queryParam("status", "PENDING_PREMODERATION")
+                        .queryParam("page", "0")
+                        .queryParam("size", "20")
+                        .header("Authorization", "Bearer $moderatorToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: PageResponseDto<OpinionDto> = objectMapper.readValue(result.response.contentAsString)
+        assertEquals(true, actual.items.any { it.id == created.id })
+        assertEquals(true, actual.items.all { it.status == OpinionStatusEnumDto.PENDING_PREMODERATION })
+    }
+
+    @Test
+    @WithMockUser
+    fun `regular user cannot list pending moderation opinions`() {
+        val accessToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+
+        mockMvc
+            .perform(
+                get("/api/opinions/moderation")
+                    .with(csrf())
+                    .queryParam("page", "0")
+                    .queryParam("size", "20")
+                    .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    @WithMockUser
+    fun `moderator can approve pending opinion`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val moderatorToken = serviceTokenService.generateAccessToken(STRANGER, listOf("MODERATOR"))
+        val created = createDraftOpinion(ownerToken, "approval subjective")
+        submitForModeration(ownerToken, created.id)
+
+        val approveResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions/${created.id}/approve")
+                        .with(csrf())
+                        .header("Authorization", "Bearer $moderatorToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: OpinionDto = objectMapper.readValue(approveResult.response.contentAsString)
+        assertEquals(created.id, actual.id)
+        assertEquals(OpinionStatusEnumDto.PUBLISHED, actual.status)
+    }
+
+    @Test
+    @WithMockUser
+    fun `moderator can reject pending opinion with reason`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val moderatorToken = serviceTokenService.generateAccessToken(STRANGER, listOf("MODERATOR"))
+        val created = createDraftOpinion(ownerToken, "rejection subjective")
+        submitForModeration(ownerToken, created.id)
+
+        val rejectResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions/${created.id}/reject")
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(
+                            objectMapper.writeValueAsString(
+                                RejectOpinionRequestDto("Please remove unsupported personal claims."),
+                            ),
+                        ).header("Authorization", "Bearer $moderatorToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val actual: OpinionDto = objectMapper.readValue(rejectResult.response.contentAsString)
+        assertEquals(created.id, actual.id)
+        assertEquals(OpinionStatusEnumDto.REJECTED, actual.status)
+    }
+
+    @Test
+    @WithMockUser
+    fun `reject opinion requires non blank reason`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val moderatorToken = serviceTokenService.generateAccessToken(STRANGER, listOf("MODERATOR"))
+        val created = createDraftOpinion(ownerToken, "blank rejection subjective")
+        submitForModeration(ownerToken, created.id)
+
+        mockMvc
+            .perform(
+                post("/api/opinions/${created.id}/reject")
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(RejectOpinionRequestDto(" ")))
+                    .header("Authorization", "Bearer $moderatorToken"),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @WithMockUser
+    fun `moderator cannot approve draft opinion`() {
+        val ownerToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+        val moderatorToken = serviceTokenService.generateAccessToken(STRANGER, listOf("MODERATOR"))
+        val created = createDraftOpinion(ownerToken, "draft approval subjective")
+
+        mockMvc
+            .perform(
+                post("/api/opinions/${created.id}/approve")
+                    .with(csrf())
+                    .header("Authorization", "Bearer $moderatorToken"),
             ).andExpect(status().isBadRequest)
     }
 
@@ -846,5 +969,37 @@ class OpinionsIntegrationTests {
                     .queryParam("weight", "0.50")
                     .header("Authorization", "Bearer $otherUserToken"),
             ).andExpect(status().isForbidden)
+    }
+
+    private fun createDraftOpinion(
+        accessToken: String?,
+        subjective: String,
+    ): OpinionDto {
+        val createResult =
+            mockMvc
+                .perform(
+                    post("/api/opinions")
+                        .with(csrf())
+                        .queryParam("subjectId", "15151515-1515-1515-1515-151515151515")
+                        .queryParam("subjective", subjective)
+                        .queryParam("objective", "moderation objective")
+                        .queryParam("mark", "5.00")
+                        .header("Authorization", "Bearer $accessToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        return objectMapper.readValue(createResult.response.contentAsString)
+    }
+
+    private fun submitForModeration(
+        accessToken: String?,
+        opinionId: UUID,
+    ) {
+        mockMvc
+            .perform(
+                post("/api/opinions/$opinionId/submit-for-moderation")
+                    .with(csrf())
+                    .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isOk)
     }
 }

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/OpinionsIntegrationTests.kt
@@ -1,6 +1,8 @@
 package com.r8n.backend.opinions
 
 import com.r8n.backend.core.api.PageResponseDto
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionActionDto
+import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionStatusEnumDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionSubjectDto
@@ -86,6 +88,8 @@ class OpinionsIntegrationTests {
             .thenReturn(bernardReferent.name)
         whenever(usersInternalApi.getUserName(eq(REQUESTER)))
             .thenReturn(bernardReferent.name)
+        whenever(usersInternalApi.getUserName(eq(STRANGER)))
+            .thenReturn("Moderator User")
     }
 
     @Test
@@ -460,6 +464,27 @@ class OpinionsIntegrationTests {
         val actual: OpinionDto = objectMapper.readValue(approveResult.response.contentAsString)
         assertEquals(created.id, actual.id)
         assertEquals(OpinionStatusEnumDto.PUBLISHED, actual.status)
+
+        val decisionsResult =
+            mockMvc
+                .perform(
+                    get("/api/opinions/moderation/decisions")
+                        .with(csrf())
+                        .queryParam("page", "0")
+                        .queryParam("size", "20")
+                        .header("Authorization", "Bearer $moderatorToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val decisions: PageResponseDto<ModerationDecisionDto> =
+            objectMapper.readValue(decisionsResult.response.contentAsString)
+        val decision = decisions.items.first { it.opinionId == created.id }
+        assertEquals(ModerationDecisionActionDto.APPROVED, decision.action)
+        assertEquals(OpinionStatusEnumDto.PENDING_PREMODERATION, decision.previousStatus)
+        assertEquals(OpinionStatusEnumDto.PUBLISHED, decision.newStatus)
+        assertEquals(STRANGER, decision.moderatorId)
+        assertEquals("Moderator User", decision.moderatorName)
+        assertEquals(null, decision.reason)
     }
 
     @Test
@@ -487,6 +512,40 @@ class OpinionsIntegrationTests {
         val actual: OpinionDto = objectMapper.readValue(rejectResult.response.contentAsString)
         assertEquals(created.id, actual.id)
         assertEquals(OpinionStatusEnumDto.REJECTED, actual.status)
+
+        val decisionsResult =
+            mockMvc
+                .perform(
+                    get("/api/opinions/moderation/decisions")
+                        .with(csrf())
+                        .queryParam("page", "0")
+                        .queryParam("size", "20")
+                        .header("Authorization", "Bearer $moderatorToken"),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val decisions: PageResponseDto<ModerationDecisionDto> =
+            objectMapper.readValue(decisionsResult.response.contentAsString)
+        val decision = decisions.items.first { it.opinionId == created.id }
+        assertEquals(ModerationDecisionActionDto.REJECTED, decision.action)
+        assertEquals(OpinionStatusEnumDto.PENDING_PREMODERATION, decision.previousStatus)
+        assertEquals(OpinionStatusEnumDto.REJECTED, decision.newStatus)
+        assertEquals("Please remove unsupported personal claims.", decision.reason)
+    }
+
+    @Test
+    @WithMockUser
+    fun `regular user cannot list moderation decisions`() {
+        val accessToken = serviceTokenService.generateAccessToken(REQUESTER, listOf("USER"))
+
+        mockMvc
+            .perform(
+                get("/api/opinions/moderation/decisions")
+                    .with(csrf())
+                    .queryParam("page", "0")
+                    .queryParam("size", "20")
+                    .header("Authorization", "Bearer $accessToken"),
+            ).andExpect(status().isForbidden)
     }
 
     @Test

--- a/frontend/e2e/ui/opinion-moderation.spec.ts
+++ b/frontend/e2e/ui/opinion-moderation.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "../../playwright-fixture";
+
+const PENDING_OPINION_ID = "e2e-opinion-pending";
+
+const moderatedOpinion = {
+  componentMark: null,
+  components: [],
+  id: PENDING_OPINION_ID,
+  mark: 8.5,
+  objective: ["Receipt from 2026-04-12", "Paid 3.20 EUR"],
+  owner: "e2e-reviewer",
+  ownerName: "E2E Reviewer",
+  status: "PUBLISHED",
+  subject: "e2e-subject",
+  subjective: ["Consistent coffee quality", "Mentions a staff member by name"],
+  subjectName: "E2E Espresso Lab",
+  timestamp: new Date().toISOString(),
+};
+
+test("moderator can review and approve a pending opinion", async ({ page }) => {
+  let approveRequested = false;
+
+  await page.route(`**/api/opinions/${PENDING_OPINION_ID}/approve`, async (route) => {
+    approveRequested = true;
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe("Bearer e2e-access-token");
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(moderatedOpinion),
+    });
+  });
+
+  await page.goto("/moderation/opinions");
+
+  await expect(page.getByRole("heading", { name: "Opinion Moderation" })).toBeVisible();
+  await expect(page.getByText("E2E Espresso Lab")).toBeVisible();
+  await expect(page.getByText(/Submitted by E2E Reviewer/)).toBeVisible();
+  await expect(page.getByText(/Consistent coffee quality/)).toBeVisible();
+  await expect(page.getByText(/Receipt from 2026-04-12/)).toBeVisible();
+  await expect(page.getByText("1 pending")).toBeVisible();
+
+  await page.getByRole("button", { name: "Approve" }).click();
+  await expect.poll(() => approveRequested).toBe(true);
+
+  await page.waitForTimeout(250);
+});
+
+test("moderator must enter a rejection reason before rejecting", async ({ page }) => {
+  let rejectionBody: unknown;
+
+  await page.route(`**/api/opinions/${PENDING_OPINION_ID}/reject`, async (route) => {
+    rejectionBody = route.request().postDataJSON();
+    expect(route.request().method()).toBe("POST");
+    expect(route.request().headers().authorization).toBe("Bearer e2e-access-token");
+
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        ...moderatedOpinion,
+        status: "REJECTED",
+      }),
+    });
+  });
+
+  await page.goto("/moderation/opinions");
+
+  await page.getByRole("button", { name: "Reject" }).click();
+  await expect(page.getByRole("dialog", { name: "Reject opinion" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Reject with reason" }).click();
+  await expect(page.getByText("Rejection reason is required.")).toBeVisible();
+  expect(rejectionBody).toBeUndefined();
+
+  await page.getByLabel("Rejection reason").fill("  Needs factual support.  ");
+  await page.getByRole("button", { name: "Reject with reason" }).click();
+
+  await expect.poll(() => rejectionBody).toEqual({
+    reason: "Needs factual support.",
+  });
+
+  await page.waitForTimeout(250);
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import RequireAuth from "@/components/auth/RequireAuth";
 import RequireRole from "@/components/auth/RequireRole";
 import AppLayout from "@/components/layout/AppLayout";
+import { seedE2eQueryData } from "@/lib/e2e/bootstrap";
 import { createQueryClient } from "@/lib/server-state";
 
 const Index = lazy(() => import("./pages/Index"));
@@ -30,6 +31,10 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = createQueryClient();
+
+if (import.meta.env.VITE_E2E_BYPASS_AUTH === "true") {
+  seedE2eQueryData(queryClient);
+}
 
 const routeLoadingFallback = (
   <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -31,8 +31,10 @@ const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
 const queryClient = createQueryClient();
+const isE2eAuthBypassEnabled =
+  import.meta.env.DEV && import.meta.env.VITE_E2E_BYPASS_AUTH === "true";
 
-if (import.meta.env.VITE_E2E_BYPASS_AUTH === "true") {
+if (isE2eAuthBypassEnabled) {
   seedE2eQueryData(queryClient);
 }
 

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -11,7 +11,8 @@ import {
 } from "@/lib/server-state/auth-store";
 
 type AuthStatus = "checking" | "authorized" | "unauthorized";
-const IS_E2E_AUTH_BYPASS_ENABLED = import.meta.env.VITE_E2E_BYPASS_AUTH === "true";
+const IS_E2E_AUTH_BYPASS_ENABLED =
+  import.meta.env.DEV && import.meta.env.VITE_E2E_BYPASS_AUTH === "true";
 
 const RequireAuth = () => {
   const [status, setStatus] = useState<AuthStatus>("checking");

--- a/frontend/src/lib/api/opinions.ts
+++ b/frontend/src/lib/api/opinions.ts
@@ -1,6 +1,11 @@
 import type { HttpClient } from "@/lib/http-client";
 import { httpClient } from "@/lib/http-client";
-import type { Uuid } from "@/lib/api/shared";
+import {
+  createPageQuery,
+  type PageRequestDto,
+  type PageResponseDto,
+  type Uuid,
+} from "@/lib/api/shared";
 
 export type OpinionStatusEnumDto =
   | "DRAFT"
@@ -65,6 +70,24 @@ export interface DeleteOpinionRequestDto {
 
 export interface SubmitOpinionForModerationRequestDto {
   opinionId: Uuid;
+}
+
+export interface GetModerationOpinionsFiltersDto {
+  status?: OpinionStatusEnumDto;
+}
+
+export interface GetModerationOpinionsRequestDto {
+  filters?: GetModerationOpinionsFiltersDto;
+  pageable: PageRequestDto;
+}
+
+export interface ModerateOpinionRequestDto {
+  opinionId: Uuid;
+}
+
+export interface RejectOpinionRequestDto {
+  opinionId: Uuid;
+  reason: string;
 }
 
 export interface LinkOpinionComponentRequestDto {
@@ -135,6 +158,33 @@ export function createOpinionsApi(client: HttpClient = httpClient) {
     ): Promise<OpinionDto> {
       return client.get<OpinionDto>(`/opinions/for/${request.subjectId}`, {
         auth: "required",
+      });
+    },
+
+    getModerationQueue(
+      request: GetModerationOpinionsRequestDto,
+    ): Promise<PageResponseDto<OpinionDto>> {
+      return client.get<PageResponseDto<OpinionDto>>("/opinions/moderation", {
+        auth: "required",
+        query: {
+          ...createPageQuery(request.pageable),
+          status: request.filters?.status,
+        },
+      });
+    },
+
+    approve(request: ModerateOpinionRequestDto): Promise<OpinionDto> {
+      return client.post<OpinionDto>(`/opinions/${request.opinionId}/approve`, {
+        auth: "required",
+      });
+    },
+
+    reject(request: RejectOpinionRequestDto): Promise<OpinionDto> {
+      return client.post<OpinionDto>(`/opinions/${request.opinionId}/reject`, {
+        auth: "required",
+        body: {
+          reason: request.reason,
+        },
       });
     },
 

--- a/frontend/src/lib/api/opinions.ts
+++ b/frontend/src/lib/api/opinions.ts
@@ -13,6 +13,8 @@ export type OpinionStatusEnumDto =
   | "PUBLISHED"
   | "REJECTED";
 
+export type ModerationDecisionActionDto = "APPROVED" | "REJECTED";
+
 export interface WeightedOpinionReferenceDto {
   id: Uuid;
   opinion: Uuid;
@@ -40,6 +42,20 @@ export interface OpinionDto {
   subjective: string[];
   subjectName: string;
   timestamp: string;
+}
+
+export interface ModerationDecisionDto {
+  action: ModerationDecisionActionDto;
+  createdAt: string;
+  id: Uuid;
+  moderatorId: Uuid;
+  moderatorName: string;
+  newStatus: OpinionStatusEnumDto;
+  opinionId: Uuid;
+  ownerName: string;
+  previousStatus: OpinionStatusEnumDto;
+  reason: string | null;
+  subjectName: string;
 }
 
 export interface GetOpinionByIdRequestDto {
@@ -78,6 +94,10 @@ export interface GetModerationOpinionsFiltersDto {
 
 export interface GetModerationOpinionsRequestDto {
   filters?: GetModerationOpinionsFiltersDto;
+  pageable: PageRequestDto;
+}
+
+export interface GetModerationDecisionsRequestDto {
   pageable: PageRequestDto;
 }
 
@@ -171,6 +191,18 @@ export function createOpinionsApi(client: HttpClient = httpClient) {
           status: request.filters?.status,
         },
       });
+    },
+
+    getModerationDecisions(
+      request: GetModerationDecisionsRequestDto,
+    ): Promise<PageResponseDto<ModerationDecisionDto>> {
+      return client.get<PageResponseDto<ModerationDecisionDto>>(
+        "/opinions/moderation/decisions",
+        {
+          auth: "required",
+          query: createPageQuery(request.pageable),
+        },
+      );
     },
 
     approve(request: ModerateOpinionRequestDto): Promise<OpinionDto> {

--- a/frontend/src/lib/api/opinions.ts
+++ b/frontend/src/lib/api/opinions.ts
@@ -88,12 +88,7 @@ export interface SubmitOpinionForModerationRequestDto {
   opinionId: Uuid;
 }
 
-export interface GetModerationOpinionsFiltersDto {
-  status?: OpinionStatusEnumDto;
-}
-
 export interface GetModerationOpinionsRequestDto {
-  filters?: GetModerationOpinionsFiltersDto;
   pageable: PageRequestDto;
 }
 
@@ -186,10 +181,7 @@ export function createOpinionsApi(client: HttpClient = httpClient) {
     ): Promise<PageResponseDto<OpinionDto>> {
       return client.get<PageResponseDto<OpinionDto>>("/opinions/moderation", {
         auth: "required",
-        query: {
-          ...createPageQuery(request.pageable),
-          status: request.filters?.status,
-        },
+        query: createPageQuery(request.pageable),
       });
     },
 

--- a/frontend/src/lib/api/opinions.ts
+++ b/frontend/src/lib/api/opinions.ts
@@ -63,6 +63,10 @@ export interface DeleteOpinionRequestDto {
   opinionId: Uuid;
 }
 
+export interface SubmitOpinionForModerationRequestDto {
+  opinionId: Uuid;
+}
+
 export interface LinkOpinionComponentRequestDto {
   childOpinionId: Uuid;
   parentOpinionId: Uuid;
@@ -107,6 +111,17 @@ export function createOpinionsApi(client: HttpClient = httpClient) {
       return client.delete<void>(`/opinions/${request.opinionId}`, {
         auth: "required",
       });
+    },
+
+    submitForModeration(
+      request: SubmitOpinionForModerationRequestDto,
+    ): Promise<OpinionDto> {
+      return client.post<OpinionDto>(
+        `/opinions/${request.opinionId}/submit-for-moderation`,
+        {
+          auth: "required",
+        },
+      );
     },
 
     getById(request: GetOpinionByIdRequestDto): Promise<OpinionDto> {

--- a/frontend/src/lib/e2e/bootstrap.ts
+++ b/frontend/src/lib/e2e/bootstrap.ts
@@ -12,12 +12,7 @@ const E2E_MODERATION_REQUEST = {
   pageable: {
     page: 0,
     size: 50,
-    sort: [
-      {
-        property: "timestamp",
-        direction: "DESC" as const,
-      },
-    ],
+    sort: [],
   },
 };
 

--- a/frontend/src/lib/e2e/bootstrap.ts
+++ b/frontend/src/lib/e2e/bootstrap.ts
@@ -6,9 +6,6 @@ import { setSession } from "@/lib/auth/session";
 import { opinionsKeys, usersKeys } from "@/lib/server-state/query-keys";
 
 const E2E_MODERATION_REQUEST = {
-  filters: {
-    status: "PENDING_PREMODERATION" as const,
-  },
   pageable: {
     page: 0,
     size: 50,

--- a/frontend/src/lib/e2e/bootstrap.ts
+++ b/frontend/src/lib/e2e/bootstrap.ts
@@ -1,0 +1,65 @@
+import type { QueryClient } from "@tanstack/react-query";
+import type { OpinionDto } from "@/lib/api/opinions";
+import type { PageResponseDto } from "@/lib/api/shared";
+import type { UsernameDto } from "@/lib/api/users";
+import { setSession } from "@/lib/auth/session";
+import { opinionsKeys, usersKeys } from "@/lib/server-state/query-keys";
+
+const E2E_MODERATION_REQUEST = {
+  filters: {
+    status: "PENDING_PREMODERATION" as const,
+  },
+  pageable: {
+    page: 0,
+    size: 50,
+    sort: [
+      {
+        property: "timestamp",
+        direction: "DESC" as const,
+      },
+    ],
+  },
+};
+
+export const E2E_PENDING_OPINION_ID = "e2e-opinion-pending";
+
+const e2eModerator: UsernameDto = {
+  id: "e2e-moderator",
+  name: "E2E Moderator",
+  roles: ["ADMIN"],
+};
+
+const e2ePendingOpinion: OpinionDto = {
+  componentMark: null,
+  components: [],
+  id: E2E_PENDING_OPINION_ID,
+  mark: 8.5,
+  objective: ["Receipt from 2026-04-12", "Paid 3.20 EUR"],
+  owner: "e2e-reviewer",
+  ownerName: "E2E Reviewer",
+  status: "PENDING_PREMODERATION",
+  subject: "e2e-subject",
+  subjective: ["Consistent coffee quality", "Mentions a staff member by name"],
+  subjectName: "E2E Espresso Lab",
+  timestamp: new Date(Date.now() - 10 * 60_000).toISOString(),
+};
+
+const e2eModerationQueue: PageResponseDto<OpinionDto> = {
+  items: [e2ePendingOpinion],
+  page: 0,
+  size: 50,
+  total: 1,
+};
+
+export function seedE2eQueryData(queryClient: QueryClient): void {
+  setSession({
+    accessToken: "e2e-access-token",
+    expiresInMilliseconds: 60 * 60_000,
+  });
+
+  queryClient.setQueryData(usersKeys.me(), e2eModerator);
+  queryClient.setQueryData(
+    opinionsKeys.moderation(E2E_MODERATION_REQUEST),
+    e2eModerationQueue,
+  );
+}

--- a/frontend/src/lib/e2e/bootstrap.ts
+++ b/frontend/src/lib/e2e/bootstrap.ts
@@ -1,5 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query";
-import type { OpinionDto } from "@/lib/api/opinions";
+import type { ModerationDecisionDto, OpinionDto } from "@/lib/api/opinions";
 import type { PageResponseDto } from "@/lib/api/shared";
 import type { UsernameDto } from "@/lib/api/users";
 import { setSession } from "@/lib/auth/session";
@@ -46,6 +46,13 @@ const e2eModerationQueue: PageResponseDto<OpinionDto> = {
   total: 1,
 };
 
+const e2eModerationDecisions: PageResponseDto<ModerationDecisionDto> = {
+  items: [],
+  page: 0,
+  size: 20,
+  total: 0,
+};
+
 export function seedE2eQueryData(queryClient: QueryClient): void {
   setSession({
     accessToken: "e2e-access-token",
@@ -56,5 +63,9 @@ export function seedE2eQueryData(queryClient: QueryClient): void {
   queryClient.setQueryData(
     opinionsKeys.moderation(E2E_MODERATION_REQUEST),
     e2eModerationQueue,
+  );
+  queryClient.setQueryData(
+    opinionsKeys.moderationDecisions({ pageable: { page: 0, size: 20, sort: [] } }),
+    e2eModerationDecisions,
   );
 }

--- a/frontend/src/lib/server-state/hooks/authorized.ts
+++ b/frontend/src/lib/server-state/hooks/authorized.ts
@@ -7,7 +7,7 @@ import type {
 } from "@tanstack/react-query";
 
 const IS_E2E_AUTH_BYPASS_ENABLED =
-  import.meta.env.VITE_E2E_BYPASS_AUTH === "true";
+  import.meta.env.DEV && import.meta.env.VITE_E2E_BYPASS_AUTH === "true";
 
 export function useAuthorizedQuery<TData, TError = Error, TQueryKey extends readonly unknown[] = readonly unknown[]>(
   options: Omit<UseQueryOptions<TData, TError, TData, TQueryKey>, "queryFn"> & {

--- a/frontend/src/lib/server-state/hooks/opinions.ts
+++ b/frontend/src/lib/server-state/hooks/opinions.ts
@@ -4,11 +4,13 @@ import type {
   AdjustOpinionComponentWeightRequestDto,
   CreateOpinionRequestDto,
   DeleteOpinionRequestDto,
+  GetModerationDecisionsRequestDto,
   GetModerationOpinionsRequestDto,
   GetOpinionByIdRequestDto,
   GetOpinionForSubjectRequestDto,
   LinkOpinionComponentRequestDto,
   ModerateOpinionRequestDto,
+  ModerationDecisionDto,
   OpinionDto,
   RejectOpinionRequestDto,
   SubmitOpinionForModerationRequestDto,
@@ -63,6 +65,25 @@ export function useModerationOpinions(
   return useAuthorizedQuery({
     queryKey: opinionsKeys.moderation(request),
     queryFn: () => opinionsApi.getModerationQueue(request),
+    ...options,
+  });
+}
+
+export function useModerationDecisions(
+  request: GetModerationDecisionsRequestDto,
+  options?: Omit<
+    UseQueryOptions<
+      PageResponseDto<ModerationDecisionDto>,
+      Error,
+      PageResponseDto<ModerationDecisionDto>,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useAuthorizedQuery({
+    queryKey: opinionsKeys.moderationDecisions(request),
+    queryFn: () => opinionsApi.getModerationDecisions(request),
     ...options,
   });
 }

--- a/frontend/src/lib/server-state/hooks/opinions.ts
+++ b/frontend/src/lib/server-state/hooks/opinions.ts
@@ -4,14 +4,18 @@ import type {
   AdjustOpinionComponentWeightRequestDto,
   CreateOpinionRequestDto,
   DeleteOpinionRequestDto,
+  GetModerationOpinionsRequestDto,
   GetOpinionByIdRequestDto,
   GetOpinionForSubjectRequestDto,
   LinkOpinionComponentRequestDto,
+  ModerateOpinionRequestDto,
   OpinionDto,
+  RejectOpinionRequestDto,
   SubmitOpinionForModerationRequestDto,
   UnlinkOpinionComponentRequestDto,
   UpdateOpinionRequestDto,
 } from "@/lib/api/opinions";
+import type { PageResponseDto } from "@/lib/api/shared";
 import { opinionListsKeys, opinionsKeys } from "@/lib/server-state/query-keys";
 import type { ApiErrorMeta } from "@/lib/server-state/query-client";
 import { useApiInvalidation, useAuthorizedMutation, useAuthorizedQuery } from "@/lib/server-state/hooks/authorized";
@@ -40,6 +44,25 @@ export function useOpinionForSubject(
   return useAuthorizedQuery({
     queryKey: opinionsKeys.forSubject(request),
     queryFn: () => opinionsApi.getForSubject(request),
+    ...options,
+  });
+}
+
+export function useModerationOpinions(
+  request: GetModerationOpinionsRequestDto,
+  options?: Omit<
+    UseQueryOptions<
+      PageResponseDto<OpinionDto>,
+      Error,
+      PageResponseDto<OpinionDto>,
+      QueryKey
+    >,
+    "queryKey" | "queryFn"
+  >,
+) {
+  return useAuthorizedQuery({
+    queryKey: opinionsKeys.moderation(request),
+    queryFn: () => opinionsApi.getModerationQueue(request),
     ...options,
   });
 }
@@ -134,6 +157,56 @@ export function useSubmitOpinionForModerationMutation(
     ...options,
     meta: {
       errorTitle: "Opinion submission failed",
+      ...options?.meta,
+    } as ApiErrorMeta,
+    onSuccess: (data, variables, context) => {
+      invalidate(opinionsKeys.all);
+      invalidate(opinionListsKeys.all);
+      options?.onSuccess?.(data, variables, context);
+    },
+  });
+}
+
+export function useApproveOpinionMutation(
+  options?: UseMutationOptions<
+    OpinionDto,
+    Error,
+    ModerateOpinionRequestDto,
+    unknown
+  >,
+) {
+  const invalidate = useApiInvalidation();
+
+  return useAuthorizedMutation({
+    mutationFn: (variables) => opinionsApi.approve(variables),
+    ...options,
+    meta: {
+      errorTitle: "Opinion approval failed",
+      ...options?.meta,
+    } as ApiErrorMeta,
+    onSuccess: (data, variables, context) => {
+      invalidate(opinionsKeys.all);
+      invalidate(opinionListsKeys.all);
+      options?.onSuccess?.(data, variables, context);
+    },
+  });
+}
+
+export function useRejectOpinionMutation(
+  options?: UseMutationOptions<
+    OpinionDto,
+    Error,
+    RejectOpinionRequestDto,
+    unknown
+  >,
+) {
+  const invalidate = useApiInvalidation();
+
+  return useAuthorizedMutation({
+    mutationFn: (variables) => opinionsApi.reject(variables),
+    ...options,
+    meta: {
+      errorTitle: "Opinion rejection failed",
       ...options?.meta,
     } as ApiErrorMeta,
     onSuccess: (data, variables, context) => {

--- a/frontend/src/lib/server-state/hooks/opinions.ts
+++ b/frontend/src/lib/server-state/hooks/opinions.ts
@@ -8,6 +8,7 @@ import type {
   GetOpinionForSubjectRequestDto,
   LinkOpinionComponentRequestDto,
   OpinionDto,
+  SubmitOpinionForModerationRequestDto,
   UnlinkOpinionComponentRequestDto,
   UpdateOpinionRequestDto,
 } from "@/lib/api/opinions";
@@ -108,6 +109,31 @@ export function useDeleteOpinionMutation(
     ...options,
     meta: {
       errorTitle: "Opinion deletion failed",
+      ...options?.meta,
+    } as ApiErrorMeta,
+    onSuccess: (data, variables, context) => {
+      invalidate(opinionsKeys.all);
+      invalidate(opinionListsKeys.all);
+      options?.onSuccess?.(data, variables, context);
+    },
+  });
+}
+
+export function useSubmitOpinionForModerationMutation(
+  options?: UseMutationOptions<
+    OpinionDto,
+    Error,
+    SubmitOpinionForModerationRequestDto,
+    unknown
+  >,
+) {
+  const invalidate = useApiInvalidation();
+
+  return useAuthorizedMutation({
+    mutationFn: (variables) => opinionsApi.submitForModeration(variables),
+    ...options,
+    meta: {
+      errorTitle: "Opinion submission failed",
       ...options?.meta,
     } as ApiErrorMeta,
     onSuccess: (data, variables, context) => {

--- a/frontend/src/lib/server-state/query-keys.ts
+++ b/frontend/src/lib/server-state/query-keys.ts
@@ -9,6 +9,7 @@ import type {
   SearchOpinionListsRequestDto,
 } from "@/lib/api/opinion-lists";
 import type {
+  GetModerationOpinionsRequestDto,
   GetOpinionByIdRequestDto,
   GetOpinionForSubjectRequestDto,
 } from "@/lib/api/opinions";
@@ -24,6 +25,12 @@ export const opinionsKeys = {
     "opinions",
     "for-subject",
     request.subjectId,
+  ] as const,
+  moderation: (request: GetModerationOpinionsRequestDto) => [
+    "opinions",
+    "moderation",
+    request.filters ?? null,
+    request.pageable,
   ] as const,
 };
 

--- a/frontend/src/lib/server-state/query-keys.ts
+++ b/frontend/src/lib/server-state/query-keys.ts
@@ -9,6 +9,7 @@ import type {
   SearchOpinionListsRequestDto,
 } from "@/lib/api/opinion-lists";
 import type {
+  GetModerationDecisionsRequestDto,
   GetModerationOpinionsRequestDto,
   GetOpinionByIdRequestDto,
   GetOpinionForSubjectRequestDto,
@@ -30,6 +31,11 @@ export const opinionsKeys = {
     "opinions",
     "moderation",
     request.filters ?? null,
+    request.pageable,
+  ] as const,
+  moderationDecisions: (request: GetModerationDecisionsRequestDto) => [
+    "opinions",
+    "moderation-decisions",
     request.pageable,
   ] as const,
 };

--- a/frontend/src/lib/server-state/query-keys.ts
+++ b/frontend/src/lib/server-state/query-keys.ts
@@ -30,7 +30,6 @@ export const opinionsKeys = {
   moderation: (request: GetModerationOpinionsRequestDto) => [
     "opinions",
     "moderation",
-    request.filters ?? null,
     request.pageable,
   ] as const,
   moderationDecisions: (request: GetModerationDecisionsRequestDto) => [

--- a/frontend/src/pages/CreateReview.tsx
+++ b/frontend/src/pages/CreateReview.tsx
@@ -6,7 +6,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useMyOpinionLists, useLinkOpinionToListMutation } from "@/lib/server-state/hooks/opinion-lists";
-import { useCreateOpinionMutation } from "@/lib/server-state/hooks/opinions";
+import { useCreateOpinionMutation, useSubmitOpinionForModerationMutation } from "@/lib/server-state/hooks/opinions";
 
 const RatingRow = ({
   label,
@@ -199,8 +199,9 @@ const CreateReview = () => {
 
   const createOpinion = useCreateOpinionMutation();
   const linkOpinion = useLinkOpinionToListMutation();
+  const submitOpinion = useSubmitOpinionForModerationMutation();
 
-  const isSubmitting = createOpinion.isPending || linkOpinion.isPending;
+  const isSubmitting = createOpinion.isPending || linkOpinion.isPending || submitOpinion.isPending;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -229,6 +230,8 @@ const CreateReview = () => {
       if (selectedList) {
         await linkOpinion.mutateAsync({ listId: selectedList, opinionId: opinion.id });
       }
+
+      await submitOpinion.mutateAsync({ opinionId: opinion.id });
 
       navigate("/");
     } catch {
@@ -381,7 +384,7 @@ const CreateReview = () => {
           {/* Submit */}
           <div className="flex gap-3 pt-2">
             <Button type="submit" className="rounded-xl px-8" disabled={isSubmitting}>
-              {isSubmitting ? "Saving…" : "Publish Review"}
+              {isSubmitting ? "Submitting…" : "Submit for Review"}
             </Button>
             <Button type="button" variant="ghost" onClick={() => navigate("/")} className="rounded-xl" disabled={isSubmitting}>
               Cancel

--- a/frontend/src/pages/OpinionModeration.tsx
+++ b/frontend/src/pages/OpinionModeration.tsx
@@ -16,9 +16,15 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
-import type { GetModerationOpinionsRequestDto, OpinionDto } from "@/lib/api/opinions";
+import type {
+  GetModerationDecisionsRequestDto,
+  GetModerationOpinionsRequestDto,
+  ModerationDecisionDto,
+  OpinionDto,
+} from "@/lib/api/opinions";
 import {
   useApproveOpinionMutation,
+  useModerationDecisions,
   useModerationOpinions,
   useRejectOpinionMutation,
 } from "@/lib/server-state/hooks/opinions";
@@ -35,7 +41,16 @@ const MODERATION_QUEUE_REQUEST = {
   },
 } satisfies GetModerationOpinionsRequestDto;
 
+const MODERATION_DECISIONS_REQUEST = {
+  pageable: {
+    page: 0,
+    size: 20,
+    sort: [],
+  },
+} satisfies GetModerationDecisionsRequestDto;
+
 const EMPTY_OPINIONS: OpinionDto[] = [];
+const EMPTY_DECISIONS: ModerationDecisionDto[] = [];
 
 function formatRelativeTime(timestamp: string): string {
   const createdAt = new Date(timestamp).getTime();
@@ -84,6 +99,7 @@ const OpinionRating = ({ opinion }: { opinion: OpinionDto }) => {
 
 const OpinionModeration = () => {
   const moderation = useModerationOpinions(MODERATION_QUEUE_REQUEST);
+  const decisions = useModerationDecisions(MODERATION_DECISIONS_REQUEST);
   const approveOpinion = useApproveOpinionMutation();
   const rejectOpinion = useRejectOpinionMutation();
   const [rejectingOpinionId, setRejectingOpinionId] = useState<string | null>(null);
@@ -91,6 +107,7 @@ const OpinionModeration = () => {
   const [rejectionError, setRejectionError] = useState<string | null>(null);
 
   const pendingOpinions = moderation.data?.items ?? EMPTY_OPINIONS;
+  const recentDecisions = decisions.data?.items ?? EMPTY_DECISIONS;
   const isMutating = approveOpinion.isPending || rejectOpinion.isPending;
   const rejectingOpinion = useMemo(
     () => pendingOpinions.find((opinion) => opinion.id === rejectingOpinionId) ?? null,
@@ -248,6 +265,67 @@ const OpinionModeration = () => {
                       <Check className="h-4 w-4" />
                       Approve
                     </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </QueryState>
+      </motion.section>
+
+      <motion.section
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3, delay: 0.15 }}
+        className="mt-12"
+      >
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold tracking-tight text-foreground">Recent decisions</h2>
+            <p className="text-sm text-muted-foreground">
+              Stored moderation actions from the current backend database.
+            </p>
+          </div>
+          <Badge variant="outline" className="rounded-full border-border px-3 py-1 text-xs font-medium">
+            {decisions.data?.total ?? recentDecisions.length} logged
+          </Badge>
+        </div>
+
+        <QueryState
+          isLoading={decisions.isLoading}
+          isError={decisions.isError}
+          error={decisions.error}
+          onRetry={() => void decisions.refetch()}
+          isEmpty={recentDecisions.length === 0}
+          loadingMessage="Loading moderation decisions..."
+          emptyMessage="No moderation decisions have been recorded yet."
+        >
+          <div className="space-y-3">
+            {recentDecisions.map((decision) => (
+              <Card key={decision.id} className="rounded-2xl border-border">
+                <CardContent className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-start md:justify-between md:px-6">
+                  <div className="min-w-0">
+                    <div className="mb-1 flex flex-wrap items-center gap-2">
+                      <p className="text-sm font-semibold text-foreground">{decision.subjectName}</p>
+                      <Badge
+                        className={cn(
+                          decision.action === "APPROVED"
+                            ? "bg-primary/10 text-primary hover:bg-primary/10"
+                            : "bg-destructive/10 text-destructive hover:bg-destructive/10",
+                        )}
+                      >
+                        {decision.action === "APPROVED" ? "Approved" : "Rejected"}
+                      </Badge>
+                    </div>
+                    <p className="text-sm text-muted-foreground">
+                      {decision.ownerName} · moderated by {decision.moderatorName} ·{" "}
+                      {formatRelativeTime(decision.createdAt)}
+                    </p>
+                    {decision.reason && (
+                      <p className="mt-3 text-sm leading-relaxed text-foreground/85">
+                        <span className="font-medium text-foreground">Reason:</span> {decision.reason}
+                      </p>
+                    )}
                   </div>
                 </CardContent>
               </Card>

--- a/frontend/src/pages/OpinionModeration.tsx
+++ b/frontend/src/pages/OpinionModeration.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { Check, X } from "lucide-react";
 import RatingBadge from "@/components/RatingBadge";
+import { QueryState } from "@/components/server-state/QueryState";
 import UserAvatar from "@/components/UserAvatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,132 +16,109 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Textarea } from "@/components/ui/textarea";
+import type { GetModerationOpinionsRequestDto, OpinionDto } from "@/lib/api/opinions";
+import {
+  useApproveOpinionMutation,
+  useModerationOpinions,
+  useRejectOpinionMutation,
+} from "@/lib/server-state/hooks/opinions";
 import { cn } from "@/lib/utils";
 
-type PendingOpinion = {
-  id: string;
-  subjectName: string;
-  subjectType: string;
-  reviewerName: string;
-  reviewerLastSeenAt: string | null;
-  submittedAt: string;
-  rating: number;
-  linkedList: string;
-  subjectiveOpinion: string;
-  objectiveFacts: string;
+const MODERATION_QUEUE_REQUEST = {
+  filters: {
+    status: "PENDING_PREMODERATION",
+  },
+  pageable: {
+    page: 0,
+    size: 50,
+    sort: [
+      {
+        property: "timestamp",
+        direction: "DESC",
+      },
+    ],
+  },
+} satisfies GetModerationOpinionsRequestDto;
+
+function formatRelativeTime(timestamp: string): string {
+  const createdAt = new Date(timestamp).getTime();
+
+  if (Number.isNaN(createdAt)) {
+    return "Submitted recently";
+  }
+
+  const diffMs = Math.max(0, Date.now() - createdAt);
+  const minutes = Math.floor(diffMs / 60_000);
+
+  if (minutes < 1) {
+    return "Just now";
+  }
+
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatOpinionText(items: readonly string[], fallback: string): string {
+  const values = items.map((item) => item.trim()).filter(Boolean);
+  return values.length > 0 ? values.join(", ") : fallback;
+}
+
+const OpinionRating = ({ opinion }: { opinion: OpinionDto }) => {
+  if (opinion.mark === null) {
+    return (
+      <Badge variant="outline" className="border-border text-muted-foreground">
+        No rating
+      </Badge>
+    );
+  }
+
+  return <RatingBadge value={opinion.mark} />;
 };
-
-type ModerationDecision = PendingOpinion & {
-  decision: "approved" | "rejected";
-  decidedAt: string;
-  rejectionReason?: string;
-};
-
-const initialPendingOpinions: PendingOpinion[] = [
-  {
-    id: "op-espresso-lab",
-    subjectName: "Espresso Lab Mitte",
-    subjectType: "Café",
-    reviewerName: "Alex Krüger",
-    reviewerLastSeenAt: new Date(Date.now() - 12 * 60_000).toISOString(),
-    submittedAt: "8 minutes ago",
-    rating: 8.5,
-    linkedList: "Best espresso in Berlin",
-    subjectiveOpinion:
-      "Excellent extraction and consistent bar work, but the review mentions a barista by name, so it should be checked before publication to a wider trusted circle.",
-    objectiveFacts: "Double espresso, medium roast, ordered on Apr 18 at 09:10, total €3.20.",
-  },
-  {
-    id: "op-minister-consulting",
-    subjectName: "Public policy consulting workshop",
-    subjectType: "Service",
-    reviewerName: "Mia Svensson",
-    reviewerLastSeenAt: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
-    submittedAt: "31 minutes ago",
-    rating: 4,
-    linkedList: "Consultants and facilitators",
-    subjectiveOpinion:
-      "Strong presentation style, but the reviewer alleges the organizer used political connections to bypass normal procurement expectations.",
-    objectiveFacts: "Half-day workshop, invoice total €1,600, attended by 6 participants.",
-  },
-  {
-    id: "op-bakery-kreuzberg",
-    subjectName: "Neighbourhood Bakery Kreuzberg",
-    subjectType: "Shop",
-    reviewerName: "Tobias Richter",
-    reviewerLastSeenAt: new Date(Date.now() - 25 * 60 * 60_000).toISOString(),
-    submittedAt: "1 hour ago",
-    rating: 7,
-    linkedList: "Weekend breakfast spots",
-    subjectiveOpinion:
-      "Great laminated pastry texture and reliable coffee, but the complaint about 'unsafe storage' should be reviewed for factual support before it stays attached to the shop.",
-    objectiveFacts: "Pain au chocolat, cappuccino, queue time ~12 minutes, paid €8.40.",
-  },
-];
-
-const recentDecisionsSeed: ModerationDecision[] = [
-  {
-    id: "resolved-vacuum-brand",
-    subjectName: "Dyson V15 Detect",
-    subjectType: "Product",
-    reviewerName: "Sophie Chen",
-    reviewerLastSeenAt: null,
-    submittedAt: "Earlier today",
-    rating: 6.5,
-    linkedList: "Home appliances 2026",
-    subjectiveOpinion: "Battery life is fine, but the draft contained an unsupported claim about hidden defects.",
-    objectiveFacts: "Home use for 3 weeks, hardwood floors, apartment size 78m².",
-    decision: "rejected",
-    decidedAt: "24 minutes ago",
-    rejectionReason: "Please remove the hidden defect claim or add verifiable facts that support it.",
-  },
-];
 
 const OpinionModeration = () => {
-  const [pendingOpinions, setPendingOpinions] = useState(initialPendingOpinions);
-  const [resolvedOpinions, setResolvedOpinions] = useState(recentDecisionsSeed);
+  const moderation = useModerationOpinions(MODERATION_QUEUE_REQUEST);
+  const approveOpinion = useApproveOpinionMutation();
+  const rejectOpinion = useRejectOpinionMutation();
   const [rejectingOpinionId, setRejectingOpinionId] = useState<string | null>(null);
   const [rejectionReason, setRejectionReason] = useState("");
   const [rejectionError, setRejectionError] = useState<string | null>(null);
 
+  const pendingOpinions = moderation.data?.items ?? [];
+  const isMutating = approveOpinion.isPending || rejectOpinion.isPending;
   const rejectingOpinion = useMemo(
     () => pendingOpinions.find((opinion) => opinion.id === rejectingOpinionId) ?? null,
     [pendingOpinions, rejectingOpinionId],
   );
 
   const closeRejectDialog = () => {
+    if (rejectOpinion.isPending) {
+      return;
+    }
+
     setRejectingOpinionId(null);
     setRejectionReason("");
     setRejectionError(null);
   };
 
-  const storeDecision = (
-    opinion: PendingOpinion,
-    decision: ModerationDecision["decision"],
-    reason?: string,
-  ) => {
-    setPendingOpinions((current) => current.filter((item) => item.id !== opinion.id));
-    setResolvedOpinions((current) => [
-      {
-        ...opinion,
-        decision,
-        decidedAt: "Just now",
-        rejectionReason: reason,
-      },
-      ...current,
-    ]);
-  };
-
-  const handleApprove = (opinionId: string) => {
-    const opinion = pendingOpinions.find((item) => item.id === opinionId);
-    if (!opinion) {
-      return;
+  const handleApprove = async (opinionId: string) => {
+    try {
+      await approveOpinion.mutateAsync({ opinionId });
+    } catch {
+      // Mutation errors are surfaced by the shared API error toast.
     }
-
-    storeDecision(opinion, "approved");
   };
 
-  const handleReject = () => {
+  const handleReject = async () => {
     if (!rejectingOpinion) {
       return;
     }
@@ -151,8 +129,15 @@ const OpinionModeration = () => {
       return;
     }
 
-    storeDecision(rejectingOpinion, "rejected", trimmedReason);
-    closeRejectDialog();
+    try {
+      await rejectOpinion.mutateAsync({
+        opinionId: rejectingOpinion.id,
+        reason: trimmedReason,
+      });
+      closeRejectDialog();
+    } catch {
+      // Mutation errors are surfaced by the shared API error toast.
+    }
   };
 
   return (
@@ -167,8 +152,8 @@ const OpinionModeration = () => {
           Opinion Moderation
         </h1>
         <p className="max-w-3xl text-sm text-muted-foreground">
-          Review submitted opinions before they move beyond private draft review. Reject actions
-          always require a reason so the author can revise the text safely.
+          Review submitted opinions before publication. Reject actions always require a reason so
+          the author can revise the text safely.
         </p>
       </motion.div>
 
@@ -176,7 +161,6 @@ const OpinionModeration = () => {
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.3, delay: 0.1 }}
-        className="mb-12"
       >
         <div className="mb-4 flex items-center justify-between gap-3">
           <div>
@@ -186,11 +170,19 @@ const OpinionModeration = () => {
             </p>
           </div>
           <Badge variant="outline" className="rounded-full border-border px-3 py-1 text-xs font-medium">
-            {pendingOpinions.length} pending
+            {moderation.data?.total ?? pendingOpinions.length} pending
           </Badge>
         </div>
 
-        {pendingOpinions.length > 0 ? (
+        <QueryState
+          isLoading={moderation.isLoading}
+          isError={moderation.isError}
+          error={moderation.error}
+          onRetry={() => void moderation.refetch()}
+          isEmpty={pendingOpinions.length === 0}
+          loadingMessage="Loading moderation queue..."
+          emptyMessage="No opinions are waiting for review."
+        >
           <div className="space-y-4">
             {pendingOpinions.map((opinion) => (
               <Card key={opinion.id} className="overflow-hidden rounded-2xl border-border">
@@ -198,28 +190,22 @@ const OpinionModeration = () => {
                   <div className="border-b border-border px-5 py-4 md:px-6">
                     <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
                       <div className="flex items-start gap-3">
-                        <UserAvatar
-                          name={opinion.reviewerName}
-                          lastSeenAt={opinion.reviewerLastSeenAt}
-                          size="md"
-                        />
+                        <UserAvatar name={opinion.ownerName} size="md" />
                         <div className="min-w-0">
                           <div className="mb-2 flex flex-wrap items-center gap-2">
                             <h3 className="text-base font-semibold text-foreground">{opinion.subjectName}</h3>
                             <Badge variant="outline" className="border-border text-muted-foreground">
-                              {opinion.subjectType}
+                              Pending review
                             </Badge>
                           </div>
                           <p className="text-sm text-muted-foreground">
-                            Submitted by {opinion.reviewerName} to{" "}
-                            <span className="font-medium text-foreground/80">{opinion.linkedList}</span> ·{" "}
-                            {opinion.submittedAt}
+                            Submitted by {opinion.ownerName} · {formatRelativeTime(opinion.timestamp)}
                           </p>
                         </div>
                       </div>
 
                       <div className="flex flex-wrap items-center gap-2 md:justify-end">
-                        <RatingBadge value={opinion.rating} />
+                        <OpinionRating opinion={opinion} />
                       </div>
                     </div>
                   </div>
@@ -230,13 +216,17 @@ const OpinionModeration = () => {
                         <p className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                           Subjective opinion
                         </p>
-                        <p className="text-sm leading-relaxed text-foreground/85">{opinion.subjectiveOpinion}</p>
+                        <p className="text-sm leading-relaxed text-foreground/85">
+                          {formatOpinionText(opinion.subjective, "No subjective opinion provided.")}
+                        </p>
                       </div>
                       <div>
                         <p className="mb-1 text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
                           Objective facts
                         </p>
-                        <p className="text-sm leading-relaxed text-muted-foreground">{opinion.objectiveFacts}</p>
+                        <p className="text-sm leading-relaxed text-muted-foreground">
+                          {formatOpinionText(opinion.objective, "No objective facts provided.")}
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -245,6 +235,7 @@ const OpinionModeration = () => {
                     <Button
                       variant="outline"
                       className="border-destructive/20 text-destructive hover:bg-destructive/5 hover:text-destructive"
+                      disabled={isMutating}
                       onClick={() => {
                         setRejectingOpinionId(opinion.id);
                         setRejectionError(null);
@@ -253,7 +244,10 @@ const OpinionModeration = () => {
                       <X className="h-4 w-4" />
                       Reject
                     </Button>
-                    <Button onClick={() => handleApprove(opinion.id)}>
+                    <Button
+                      disabled={isMutating}
+                      onClick={() => void handleApprove(opinion.id)}
+                    >
                       <Check className="h-4 w-4" />
                       Approve
                     </Button>
@@ -262,68 +256,7 @@ const OpinionModeration = () => {
               </Card>
             ))}
           </div>
-        ) : (
-          <Card className="rounded-2xl border-dashed border-border">
-            <CardContent className="py-14 text-center">
-              <p className="text-base font-medium text-foreground">No opinions are waiting for review.</p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                New submissions will appear here as soon as they enter the moderation queue.
-              </p>
-            </CardContent>
-          </Card>
-        )}
-      </motion.section>
-
-      <motion.section
-        initial={{ opacity: 0, y: 8 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.3, delay: 0.15 }}
-      >
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-semibold tracking-tight text-foreground">Recent decisions</h2>
-            <p className="text-sm text-muted-foreground">
-              Useful for checking the latest moderator actions.
-            </p>
-          </div>
-          <Badge variant="outline" className="rounded-full border-border px-3 py-1 text-xs font-medium">
-            {resolvedOpinions.length} logged
-          </Badge>
-        </div>
-
-        <div className="space-y-3">
-          {resolvedOpinions.map((opinion) => (
-            <Card key={opinion.id} className="rounded-2xl border-border">
-              <CardContent className="flex flex-col gap-4 px-5 py-4 md:flex-row md:items-start md:justify-between md:px-6">
-                <div className="min-w-0">
-                  <div className="mb-1 flex flex-wrap items-center gap-2">
-                    <p className="text-sm font-semibold text-foreground">{opinion.subjectName}</p>
-                    <Badge
-                      className={cn(
-                        opinion.decision === "approved"
-                          ? "bg-primary/10 text-primary hover:bg-primary/10"
-                          : "bg-destructive/10 text-destructive hover:bg-destructive/10",
-                      )}
-                    >
-                      {opinion.decision === "approved" ? "Approved" : "Rejected"}
-                    </Badge>
-                  </div>
-                  <p className="text-sm text-muted-foreground">
-                    {opinion.reviewerName} · {opinion.decidedAt}
-                  </p>
-                  {opinion.rejectionReason && (
-                    <p className="mt-3 text-sm leading-relaxed text-foreground/85">
-                      <span className="font-medium text-foreground">Reason:</span> {opinion.rejectionReason}
-                    </p>
-                  )}
-                </div>
-                <div className="flex items-center gap-2">
-                  <RatingBadge value={opinion.rating} />
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+        </QueryState>
       </motion.section>
 
       <Dialog open={Boolean(rejectingOpinion)} onOpenChange={(open) => !open && closeRejectDialog()}>
@@ -343,6 +276,7 @@ const OpinionModeration = () => {
             <Textarea
               id="rejection-reason"
               value={rejectionReason}
+              disabled={rejectOpinion.isPending}
               onChange={(event) => {
                 setRejectionReason(event.target.value);
                 if (rejectionError) {
@@ -356,10 +290,18 @@ const OpinionModeration = () => {
           </div>
 
           <DialogFooter>
-            <Button variant="outline" onClick={closeRejectDialog}>
+            <Button
+              variant="outline"
+              disabled={rejectOpinion.isPending}
+              onClick={closeRejectDialog}
+            >
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleReject}>
+            <Button
+              variant="destructive"
+              disabled={rejectOpinion.isPending}
+              onClick={() => void handleReject()}
+            >
               Reject with reason
             </Button>
           </DialogFooter>

--- a/frontend/src/pages/OpinionModeration.tsx
+++ b/frontend/src/pages/OpinionModeration.tsx
@@ -40,6 +40,8 @@ const MODERATION_QUEUE_REQUEST = {
   },
 } satisfies GetModerationOpinionsRequestDto;
 
+const EMPTY_OPINIONS: OpinionDto[] = [];
+
 function formatRelativeTime(timestamp: string): string {
   const createdAt = new Date(timestamp).getTime();
 
@@ -93,7 +95,7 @@ const OpinionModeration = () => {
   const [rejectionReason, setRejectionReason] = useState("");
   const [rejectionError, setRejectionError] = useState<string | null>(null);
 
-  const pendingOpinions = moderation.data?.items ?? [];
+  const pendingOpinions = moderation.data?.items ?? EMPTY_OPINIONS;
   const isMutating = approveOpinion.isPending || rejectOpinion.isPending;
   const rejectingOpinion = useMemo(
     () => pendingOpinions.find((opinion) => opinion.id === rejectingOpinionId) ?? null,

--- a/frontend/src/pages/OpinionModeration.tsx
+++ b/frontend/src/pages/OpinionModeration.tsx
@@ -31,12 +31,7 @@ const MODERATION_QUEUE_REQUEST = {
   pageable: {
     page: 0,
     size: 50,
-    sort: [
-      {
-        property: "timestamp",
-        direction: "DESC",
-      },
-    ],
+    sort: [],
   },
 } satisfies GetModerationOpinionsRequestDto;
 

--- a/frontend/src/pages/OpinionModeration.tsx
+++ b/frontend/src/pages/OpinionModeration.tsx
@@ -31,9 +31,6 @@ import {
 import { cn } from "@/lib/utils";
 
 const MODERATION_QUEUE_REQUEST = {
-  filters: {
-    status: "PENDING_PREMODERATION",
-  },
   pageable: {
     page: 0,
     size: 50,

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -516,7 +516,7 @@ describe("API modules", () => {
       pageable: {
         page: 0,
         size: 20,
-        sort: [{ direction: "DESC", property: "timestamp" }],
+        sort: [],
       },
     });
     await opinionsApi.approve({
@@ -528,7 +528,7 @@ describe("API modules", () => {
     });
 
     expect(fetchMock.mock.calls[0][0]).toBe(
-      "/api/opinions/moderation?page=0&size=20&sort=timestamp%2CDESC&status=PENDING_PREMODERATION",
+      "/api/opinions/moderation?page=0&size=20&status=PENDING_PREMODERATION",
     );
     expect(fetchMock.mock.calls[1][0]).toBe(
       "/api/opinions/11111111-1111-1111-1111-111111111111/approve",

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -445,6 +445,9 @@ describe("API modules", () => {
     await opinionsApi.delete({
       opinionId: "44444444-4444-4444-4444-444444444444",
     });
+    await opinionsApi.submitForModeration({
+      opinionId: "77777777-7777-7777-7777-777777777777",
+    });
     await opinionsApi.unlinkComponent({
       linkId: "55555555-5555-5555-5555-555555555555",
     });
@@ -466,9 +469,12 @@ describe("API modules", () => {
       "/api/opinions/44444444-4444-4444-4444-444444444444",
     );
     expect(fetchMock.mock.calls[4][0]).toBe(
-      "/api/opinions/unlink/55555555-5555-5555-5555-555555555555",
+      "/api/opinions/77777777-7777-7777-7777-777777777777/submit-for-moderation",
     );
     expect(fetchMock.mock.calls[5][0]).toBe(
+      "/api/opinions/unlink/55555555-5555-5555-5555-555555555555",
+    );
+    expect(fetchMock.mock.calls[6][0]).toBe(
       "/api/opinions/adjust-weight/66666666-6666-6666-6666-666666666666?weight=0.5",
     );
 
@@ -480,6 +486,9 @@ describe("API modules", () => {
     );
     expect(fetchMock.mock.calls[3][1]).toEqual(
       expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(fetchMock.mock.calls[4][1]).toEqual(
+      expect.objectContaining({ method: "POST" }),
     );
     expect(new Headers(fetchMock.mock.calls[0][1].headers).get("Authorization")).toBe(
       "Bearer stub-access-token-123",

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -512,7 +512,6 @@ describe("API modules", () => {
     const opinionsApi = createOpinionsApi(client);
 
     await opinionsApi.getModerationQueue({
-      filters: { status: "PENDING_PREMODERATION" },
       pageable: {
         page: 0,
         size: 20,
@@ -535,7 +534,7 @@ describe("API modules", () => {
     });
 
     expect(fetchMock.mock.calls[0][0]).toBe(
-      "/api/opinions/moderation?page=0&size=20&status=PENDING_PREMODERATION",
+      "/api/opinions/moderation?page=0&size=20",
     );
     expect(fetchMock.mock.calls[1][0]).toBe(
       "/api/opinions/moderation/decisions?page=0&size=20",

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -519,6 +519,13 @@ describe("API modules", () => {
         sort: [],
       },
     });
+    await opinionsApi.getModerationDecisions({
+      pageable: {
+        page: 0,
+        size: 20,
+        sort: [],
+      },
+    });
     await opinionsApi.approve({
       opinionId: "11111111-1111-1111-1111-111111111111",
     });
@@ -531,9 +538,12 @@ describe("API modules", () => {
       "/api/opinions/moderation?page=0&size=20&status=PENDING_PREMODERATION",
     );
     expect(fetchMock.mock.calls[1][0]).toBe(
-      "/api/opinions/11111111-1111-1111-1111-111111111111/approve",
+      "/api/opinions/moderation/decisions?page=0&size=20",
     );
     expect(fetchMock.mock.calls[2][0]).toBe(
+      "/api/opinions/11111111-1111-1111-1111-111111111111/approve",
+    );
+    expect(fetchMock.mock.calls[3][0]).toBe(
       "/api/opinions/22222222-2222-2222-2222-222222222222/reject",
     );
 
@@ -541,9 +551,12 @@ describe("API modules", () => {
       expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock.mock.calls[1][1]).toEqual(
-      expect.objectContaining({ method: "POST" }),
+      expect.objectContaining({ method: "GET" }),
     );
     expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock.mock.calls[3][1]).toEqual(
       expect.objectContaining({
         body: JSON.stringify({
           reason: "Please remove unsupported personal claims.",
@@ -552,7 +565,7 @@ describe("API modules", () => {
       }),
     );
 
-    const rejectHeaders = new Headers(fetchMock.mock.calls[2][1].headers);
+    const rejectHeaders = new Headers(fetchMock.mock.calls[3][1].headers);
     expect(rejectHeaders.get("Authorization")).toBe("Bearer stub-access-token-123");
     expect(rejectHeaders.get("X-XSRF-TOKEN")).toBe("xsrf-token");
   });

--- a/frontend/src/test/api-modules.test.ts
+++ b/frontend/src/test/api-modules.test.ts
@@ -495,6 +495,68 @@ describe("API modules", () => {
     );
   });
 
+  it("uses backend routes for opinion moderation", async () => {
+    setCookie("XSRF-TOKEN", "xsrf-token");
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(
+      createJsonResponse({
+        items: [],
+        page: 0,
+        size: 20,
+        total: 0,
+      }),
+    ));
+    const client = createHttpClient({
+      baseUrl: "/api",
+      fetchFn: fetchMock,
+    });
+    const opinionsApi = createOpinionsApi(client);
+
+    await opinionsApi.getModerationQueue({
+      filters: { status: "PENDING_PREMODERATION" },
+      pageable: {
+        page: 0,
+        size: 20,
+        sort: [{ direction: "DESC", property: "timestamp" }],
+      },
+    });
+    await opinionsApi.approve({
+      opinionId: "11111111-1111-1111-1111-111111111111",
+    });
+    await opinionsApi.reject({
+      opinionId: "22222222-2222-2222-2222-222222222222",
+      reason: "Please remove unsupported personal claims.",
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/opinions/moderation?page=0&size=20&sort=timestamp%2CDESC&status=PENDING_PREMODERATION",
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/api/opinions/11111111-1111-1111-1111-111111111111/approve",
+    );
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      "/api/opinions/22222222-2222-2222-2222-222222222222/reject",
+    );
+
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({ method: "GET" }),
+    );
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchMock.mock.calls[2][1]).toEqual(
+      expect.objectContaining({
+        body: JSON.stringify({
+          reason: "Please remove unsupported personal claims.",
+        }),
+        method: "POST",
+      }),
+    );
+
+    const rejectHeaders = new Headers(fetchMock.mock.calls[2][1].headers);
+    expect(rejectHeaders.get("Authorization")).toBe("Bearer stub-access-token-123");
+    expect(rejectHeaders.get("X-XSRF-TOKEN")).toBe("xsrf-token");
+  });
+
   it("uses backend path parameters and query names for opinion lists", async () => {
     const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(createJsonResponse({})));
     const client = createHttpClient({

--- a/frontend/src/test/opinion-moderation.test.tsx
+++ b/frontend/src/test/opinion-moderation.test.tsx
@@ -1,21 +1,24 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import OpinionModeration from "@/pages/OpinionModeration";
-import type { OpinionDto } from "@/lib/api/opinions";
+import type { ModerationDecisionDto, OpinionDto } from "@/lib/api/opinions";
 import type { PageResponseDto } from "@/lib/api/shared";
 import {
   useApproveOpinionMutation,
+  useModerationDecisions,
   useModerationOpinions,
   useRejectOpinionMutation,
 } from "@/lib/server-state/hooks/opinions";
 
 vi.mock("@/lib/server-state/hooks/opinions", () => ({
   useApproveOpinionMutation: vi.fn(),
+  useModerationDecisions: vi.fn(),
   useModerationOpinions: vi.fn(),
   useRejectOpinionMutation: vi.fn(),
 }));
 
 const mockUseModerationOpinions = vi.mocked(useModerationOpinions);
+const mockUseModerationDecisions = vi.mocked(useModerationDecisions);
 const mockUseApproveOpinionMutation = vi.mocked(useApproveOpinionMutation);
 const mockUseRejectOpinionMutation = vi.mocked(useRejectOpinionMutation);
 
@@ -38,7 +41,21 @@ const pendingOpinion: OpinionDto = {
   timestamp: new Date(Date.now() - 10 * 60_000).toISOString(),
 };
 
-function pageResponse(items: OpinionDto[]): PageResponseDto<OpinionDto> {
+const rejectedDecision: ModerationDecisionDto = {
+  action: "REJECTED",
+  createdAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+  id: "decision-1",
+  moderatorId: "moderator-1",
+  moderatorName: "Morgan Moderator",
+  newStatus: "REJECTED",
+  opinionId: "opinion-2",
+  ownerName: "Rejected Reviewer",
+  previousStatus: "PENDING_PREMODERATION",
+  reason: "Needs factual support.",
+  subjectName: "Rejected Espresso",
+};
+
+function pageResponse<TItem>(items: TItem[]): PageResponseDto<TItem> {
   return {
     items,
     page: 0,
@@ -58,11 +75,23 @@ function mockModerationQuery(overrides: Record<string, unknown> = {}) {
   } as ReturnType<typeof useModerationOpinions>);
 }
 
+function mockDecisionQuery(overrides: Record<string, unknown> = {}) {
+  mockUseModerationDecisions.mockReturnValue({
+    data: pageResponse([rejectedDecision]),
+    error: null,
+    isError: false,
+    isLoading: false,
+    refetch,
+    ...overrides,
+  } as ReturnType<typeof useModerationDecisions>);
+}
+
 describe("OpinionModeration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
     mockModerationQuery();
+    mockDecisionQuery();
     mockUseApproveOpinionMutation.mockReturnValue({
       isPending: false,
       mutateAsync: approveMutateAsync,
@@ -91,7 +120,16 @@ describe("OpinionModeration", () => {
     expect(screen.getByText(/Consistent coffee quality/)).toBeInTheDocument();
     expect(screen.getByText(/Receipt from 2026-04-12/)).toBeInTheDocument();
     expect(screen.getByText("1 pending")).toBeInTheDocument();
-    expect(screen.queryByText("Recent decisions")).not.toBeInTheDocument();
+    expect(screen.getByText("Recent decisions")).toBeInTheDocument();
+    expect(screen.getByText("Rejected Espresso")).toBeInTheDocument();
+    expect(screen.getByText("Needs factual support.")).toBeInTheDocument();
+    expect(mockUseModerationDecisions).toHaveBeenCalledWith({
+      pageable: {
+        page: 0,
+        size: 20,
+        sort: [],
+      },
+    });
   });
 
   it("shows loading, empty, and error states", () => {

--- a/frontend/src/test/opinion-moderation.test.tsx
+++ b/frontend/src/test/opinion-moderation.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import OpinionModeration from "@/pages/OpinionModeration";
+import type { OpinionDto } from "@/lib/api/opinions";
+import type { PageResponseDto } from "@/lib/api/shared";
+import {
+  useApproveOpinionMutation,
+  useModerationOpinions,
+  useRejectOpinionMutation,
+} from "@/lib/server-state/hooks/opinions";
+
+vi.mock("@/lib/server-state/hooks/opinions", () => ({
+  useApproveOpinionMutation: vi.fn(),
+  useModerationOpinions: vi.fn(),
+  useRejectOpinionMutation: vi.fn(),
+}));
+
+const mockUseModerationOpinions = vi.mocked(useModerationOpinions);
+const mockUseApproveOpinionMutation = vi.mocked(useApproveOpinionMutation);
+const mockUseRejectOpinionMutation = vi.mocked(useRejectOpinionMutation);
+
+const approveMutateAsync = vi.fn();
+const rejectMutateAsync = vi.fn();
+const refetch = vi.fn();
+
+const pendingOpinion: OpinionDto = {
+  componentMark: null,
+  components: [],
+  id: "opinion-1",
+  mark: 8.5,
+  objective: ["Receipt from 2026-04-12", "Paid 3.20 EUR"],
+  owner: "user-1",
+  ownerName: "Alex Reviewer",
+  status: "PENDING_PREMODERATION",
+  subject: "subject-1",
+  subjective: ["Consistent coffee quality", "Mentions a staff member by name"],
+  subjectName: "Espresso Lab Mitte",
+  timestamp: new Date(Date.now() - 10 * 60_000).toISOString(),
+};
+
+function pageResponse(items: OpinionDto[]): PageResponseDto<OpinionDto> {
+  return {
+    items,
+    page: 0,
+    size: 50,
+    total: items.length,
+  };
+}
+
+function mockModerationQuery(overrides: Record<string, unknown> = {}) {
+  mockUseModerationOpinions.mockReturnValue({
+    data: pageResponse([pendingOpinion]),
+    error: null,
+    isError: false,
+    isLoading: false,
+    refetch,
+    ...overrides,
+  } as ReturnType<typeof useModerationOpinions>);
+}
+
+describe("OpinionModeration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockModerationQuery();
+    mockUseApproveOpinionMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: approveMutateAsync,
+    } as ReturnType<typeof useApproveOpinionMutation>);
+    mockUseRejectOpinionMutation.mockReturnValue({
+      isPending: false,
+      mutateAsync: rejectMutateAsync,
+    } as ReturnType<typeof useRejectOpinionMutation>);
+  });
+
+  it("loads the pending moderation queue from server state", () => {
+    render(<OpinionModeration />);
+
+    expect(mockUseModerationOpinions).toHaveBeenCalledWith({
+      filters: {
+        status: "PENDING_PREMODERATION",
+      },
+      pageable: {
+        page: 0,
+        size: 50,
+        sort: [
+          {
+            property: "timestamp",
+            direction: "DESC",
+          },
+        ],
+      },
+    });
+    expect(screen.getByText("Espresso Lab Mitte")).toBeInTheDocument();
+    expect(screen.getByText(/Submitted by Alex Reviewer/)).toBeInTheDocument();
+    expect(screen.getByText(/Consistent coffee quality/)).toBeInTheDocument();
+    expect(screen.getByText(/Receipt from 2026-04-12/)).toBeInTheDocument();
+    expect(screen.getByText("1 pending")).toBeInTheDocument();
+    expect(screen.queryByText("Recent decisions")).not.toBeInTheDocument();
+  });
+
+  it("shows loading, empty, and error states", () => {
+    mockModerationQuery({
+      data: undefined,
+      isLoading: true,
+    });
+    const { rerender } = render(<OpinionModeration />);
+    expect(screen.getByText("Loading moderation queue...")).toBeInTheDocument();
+
+    mockModerationQuery({
+      data: pageResponse([]),
+    });
+    rerender(<OpinionModeration />);
+    expect(screen.getByText("No opinions are waiting for review.")).toBeInTheDocument();
+
+    mockModerationQuery({
+      data: undefined,
+      error: new Error("Forbidden"),
+      isError: true,
+    });
+    rerender(<OpinionModeration />);
+    expect(screen.getByText("Unable to load")).toBeInTheDocument();
+    expect(screen.getByText("Forbidden")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("approves a pending opinion", async () => {
+    approveMutateAsync.mockResolvedValue(pendingOpinion);
+
+    render(<OpinionModeration />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() => {
+      expect(approveMutateAsync).toHaveBeenCalledWith({
+        opinionId: "opinion-1",
+      });
+    });
+  });
+
+  it("requires a rejection reason and submits the trimmed reason", async () => {
+    rejectMutateAsync.mockResolvedValue({
+      ...pendingOpinion,
+      status: "REJECTED",
+    });
+
+    render(<OpinionModeration />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Reject" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reject with reason" }));
+
+    expect(screen.getByText("Rejection reason is required.")).toBeInTheDocument();
+    expect(rejectMutateAsync).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByLabelText("Rejection reason"), {
+      target: {
+        value: "  Needs factual support.  ",
+      },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Reject with reason" }));
+
+    await waitFor(() => {
+      expect(rejectMutateAsync).toHaveBeenCalledWith({
+        opinionId: "opinion-1",
+        reason: "Needs factual support.",
+      });
+    });
+  });
+});

--- a/frontend/src/test/opinion-moderation.test.tsx
+++ b/frontend/src/test/opinion-moderation.test.tsx
@@ -83,12 +83,7 @@ describe("OpinionModeration", () => {
       pageable: {
         page: 0,
         size: 50,
-        sort: [
-          {
-            property: "timestamp",
-            direction: "DESC",
-          },
-        ],
+        sort: [],
       },
     });
     expect(screen.getByText("Espresso Lab Mitte")).toBeInTheDocument();

--- a/frontend/src/test/opinion-moderation.test.tsx
+++ b/frontend/src/test/opinion-moderation.test.tsx
@@ -106,9 +106,6 @@ describe("OpinionModeration", () => {
     render(<OpinionModeration />);
 
     expect(mockUseModerationOpinions).toHaveBeenCalledWith({
-      filters: {
-        status: "PENDING_PREMODERATION",
-      },
       pageable: {
         page: 0,
         size: 50,


### PR DESCRIPTION
## Summary

Implements the moderator-side opinion approval flow across backend, frontend, persistence, and tests.

This change connects the moderation page to real backend APIs instead of relying on mock-only behavior. Moderators can now review pending opinions, approve or reject them, and have those decisions persisted in the database for auditability.

## Target Changes

### Backend

- Added moderator approval and rejection handling for pending opinions.
- Added persistence for moderation decisions in `opinions.moderation_decisions`.
- Stored moderation decision metadata:
  - opinion id
  - moderator id
  - action: `APPROVED` or `REJECTED`
  - previous status
  - new status
  - optional rejection reason
  - creation timestamp
- Added API contract DTOs for moderation decisions.
- Added API endpoint for listing recent moderation decisions.
- Ensured rejection requires a non-empty reason.
- Ensured only pending opinions can be approved or rejected.
- Added integration test coverage for:
  - approving a pending opinion
  - rejecting a pending opinion with reason
  - storing moderation decision records
  - preventing regular users from listing moderation decisions

### Frontend

- Added typed API client support for moderation decisions.
- Added React Query hook for loading moderation decision history.
- Connected the moderation page to backend-backed pending opinions.
- Added approve and reject mutations.
- Invalidated related opinion queries after moderation actions.
- Added `Recent decisions` UI backed by persisted moderation decision data.
- Added loading, error, and empty states for moderation-backed data.
- Added frontend unit coverage for moderation API wiring and page behavior.
- Added Playwright E2E coverage for the moderation page flow.

## Moderation Flow

1. A user submits an opinion.
2. The opinion is stored with status `PENDING_PREMODERATION`.
3. A moderator opens `/moderation/opinions`.
4. The frontend loads pending opinions from the backend.
5. The moderator approves or rejects the opinion.
6. The backend validates the transition.
7. The opinion status is updated:
   - approve -> `PUBLISHED`
   - reject -> `REJECTED`
8. The backend stores an audit record in `opinions.moderation_decisions`.
9. The frontend refreshes moderation data and shows the decision in `Recent decisions`.



## Manual Verification - if you want to observe each step and use webpage as a moderator

1. Start 

```bash
make docker-up
```


2. Logs in as:

anna@r8n.test: normal opinion owner
lena@r8n.test: moderator

```bash
API="https://localhost:8443"

login() {
  email="$1"
  cookie_file="$(mktemp)"
  csrf_headers="$(curl -k -s -c "$cookie_file" -i "$API/api/auth/csrf" | tr -d '\r')"
  csrf_token="$(printf "%s" "$csrf_headers" | sed -n 's/.*XSRF-TOKEN=\([^;]*\).*/\1/p' | head -n1)"

  curl -k -s -b "$cookie_file" -c "$cookie_file" \
    -X POST "$API/api/auth/login" \
    -H "Content-Type: application/json" \
    -H "X-XSRF-TOKEN: $csrf_token" \
    -d "{\"login\":\"$email\",\"password\":\"1234\"}" \
    | sed -n 's/.*"accessToken":"\([^"]*\)".*/\1/p'
}

json_id() {
  sed -n 's/.*"id":"\([^"]*\)".*/\1/p'
}

OWNER_TOKEN="$(login anna@r8n.test)"
MODERATOR_TOKEN="$(login lena@r8n.test)"
```

3. Create the subject (thing being reviewed)

```bash
SUBJECT_JSON="$(
  curl -k -s -X POST "$API/api/subjects" \
    -H "Authorization: Bearer $OWNER_TOKEN" \
    -H "Content-Type: application/json" \
    -d '{
      "name": "Moderation Test Cafe",
      "referentName": "Moderation Test Cafe Berlin",
      "address": "Teststrasse 1, Berlin",
      "latitude": 52.52,
      "longitude": 13.405
    }'
)"
SUBJECT_ID="$(printf "%s" "$SUBJECT_JSON" | json_id)"
echo "$SUBJECT_JSON"
```

4. Create a draft opinion for that subject

```bash
OPINION_JSON="$(
  curl -k -s -X POST "$API/api/opinions" \
    -H "Authorization: Bearer $OWNER_TOKEN" \
    --data-urlencode "subjectId=$SUBJECT_ID" \
    --data-urlencode "mark=4.5" \
    --data-urlencode "subjective=Good coffee, calm room" \
    --data-urlencode "objective=Paid 4.20 EUR for espresso"
)"
OPINION_ID="$(printf "%s" "$OPINION_JSON" | json_id)"
echo "$OPINION_JSON"
```

5. Submit it to moderation

```bash
curl -k -s -X POST "$API/api/opinions/$OPINION_ID/submit-for-moderation" \
  -H "Authorization: Bearer $OWNER_TOKEN"
echo
```

7. Verify it appears on `https://localhost:8443/moderation/opinions`:

<img width="1234" height="778" alt="image" src="https://github.com/user-attachments/assets/94cef9c9-4c13-4fa3-b70b-fe1b95936ee1" />

Here you can reject it with some reason or just approve it:

<img width="1233" height="776" alt="image" src="https://github.com/user-attachments/assets/69c43a61-81b0-4dbb-b6a4-ffc9d42248d5" />

8. After moderation check if it appears in the "Recent decisions":

<img width="1237" height="777" alt="image" src="https://github.com/user-attachments/assets/6dfb658d-0ded-4a59-865b-8eb922110fcc" />

9. Do something (reload the page / logout and login again / etc) to see that changes are preserved



