### PR TITLE
146 disconnect an existing incoming access request

### DIFF
--- a/frontend/src/pages/Requests.tsx
+++ b/frontend/src/pages/Requests.tsx
@@ -241,6 +241,16 @@ const Requests = () => {
                     <Check className="h-3 w-3" />
                     Approved
                   </span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-8 rounded-lg text-xs text-destructive hover:text-destructive"
+                    disabled={decline.isPending}
+                    onClick={() => decline.mutate({ requestId: req.id })}
+                  >
+                    <XCircle className="mr-1 h-3 w-3" />
+                    Revoke
+                  </Button>
                 </div>
               ))}
             </div>

--- a/frontend/src/test/requests.test.tsx
+++ b/frontend/src/test/requests.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import Requests from "@/pages/Requests";
+
+const {
+  acceptMutate,
+  cancelMutate,
+  declineMutate,
+  hideMutate,
+} = vi.hoisted(() => ({
+  acceptMutate: vi.fn(),
+  cancelMutate: vi.fn(),
+  declineMutate: vi.fn(),
+  hideMutate: vi.fn(),
+}));
+
+vi.mock("@/components/UserAvatar", () => ({
+  default: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+vi.mock("@/lib/server-state/hooks/access-requests", () => ({
+  useIncomingAccessRequests: vi.fn((request) => {
+    if (request.filters?.status === "ACCEPTED") {
+      return {
+        data: {
+          items: [
+            {
+              id: "11111111-1111-1111-1111-111111111111",
+              opinionListId: "22222222-2222-2222-2222-222222222222",
+              opinionListName: "Private Cafe List",
+              owner: "33333333-3333-3333-3333-333333333333",
+              ownerName: "Owner User",
+              requester: "44444444-4444-4444-4444-444444444444",
+              requesterName: "Requester User",
+              status: "ACCEPTED",
+              timestamp: "2026-04-29T08:00:00.000Z",
+            },
+          ],
+          total: 1,
+        },
+        error: null,
+        isError: false,
+        isLoading: false,
+        refetch: vi.fn(),
+      };
+    }
+
+    return {
+      data: { items: [], total: 0 },
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: vi.fn(),
+    };
+  }),
+  useOutgoingAccessRequests: vi.fn(() => ({
+    data: { items: [], total: 0 },
+    error: null,
+    isError: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  })),
+  useAcceptIncomingAccessRequestMutation: vi.fn(() => ({
+    isPending: false,
+    mutate: acceptMutate,
+  })),
+  useDeclineIncomingAccessRequestMutation: vi.fn(() => ({
+    isPending: false,
+    mutate: declineMutate,
+  })),
+  useHideIncomingAccessRequestMutation: vi.fn(() => ({
+    isPending: false,
+    mutate: hideMutate,
+  })),
+  useCancelOutgoingAccessRequestMutation: vi.fn(() => ({
+    isPending: false,
+    mutate: cancelMutate,
+  })),
+}));
+
+describe("Requests page", () => {
+  it("lets an owner revoke an approved incoming access request", () => {
+    render(<Requests />);
+
+    fireEvent.click(screen.getByRole("button", { name: /show access granted/i }));
+    fireEvent.click(screen.getByRole("button", { name: /revoke/i }));
+
+    expect(declineMutate).toHaveBeenCalledWith({
+      requestId: "11111111-1111-1111-1111-111111111111",
+    });
+  });
+});


### PR DESCRIPTION
## PR Description

Fixes #146 by exposing revocation for already-approved incoming access requests.

The backend already supports the required behavior: an owner can decline an `ACCEPTED` incoming access request, which changes its status to `REJECTED`. Access checks only grant requester access for requests with status `ACCEPTED`, so declining an approved request revokes the requester’s rights without affecting the owner’s own access.

This PR adds the missing frontend action: approved incoming requests now show a `Revoke` button in the Requests page. The button uses the existing decline mutation and backend `/api/access-requests/incoming/{requestId}/decline` endpoint.

## Target Changes

- Added `Revoke` action for approved incoming access requests on the frontend.
- Reused the existing `declineIncoming` API/mutation path.
- Added a frontend regression test confirming the approved-row revoke action calls decline with the correct request id.

## Manual Verification

- Log in as test@test.test, navigate to "Requests"
- Approve **Anna Müller "My Berlin coffee picks"**
- Log in as anna@r8n.test and check that you have an **approved outgoing** request for **Test Testsson** "My Berlin coffee picks"
- Log in as test@test.test, revoke request for **Anna Müller "My Berlin coffee picks"**
- Log in as anna@r8n.test, check that you have a **declined outgoing** request for **Test Testsson** "UNKNOWN" (name is now hidden due to privacy regards)
