### PR TITLE
181 docs for swagger (export, messaging, opinions, users)

### DIFF
--- a/backend/export-sv/api/src/main/kotlin/com/r8n/backend/export/api/ExportApi.kt
+++ b/backend/export-sv/api/src/main/kotlin/com/r8n/backend/export/api/ExportApi.kt
@@ -2,10 +2,13 @@ package com.r8n.backend.export.api
 
 import com.r8n.backend.export.api.dto.ExportStateDto
 import com.r8n.backend.export.api.dto.UserCompleteDataDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 
+@Tag(name = "Data export", description = "Self-service export of the authenticated user's stored data.")
 interface ExportApi {
     companion object {
         private const val BASE_PATH = "/api/export"
@@ -15,11 +18,23 @@ interface ExportApi {
     }
 
     @PostMapping(START_PATH)
+    @Operation(
+        summary = "Start data export",
+        description = "Queues generation of the authenticated user's complete data export and returns immediately.",
+    )
     fun startGeneratingExportFor(): ResponseEntity<Void>
 
     @GetMapping(STATUS_PATH)
+    @Operation(
+        summary = "Get export status",
+        description = "Returns whether the authenticated user's generated data export is ready to download.",
+    )
     fun checkIfDataIsReady(): ExportStateDto
 
     @GetMapping(DOWNLOAD_PATH)
+    @Operation(
+        summary = "Download data export",
+        description = "Returns the authenticated user's generated data export when it is ready.",
+    )
     fun downloadData(): UserCompleteDataDto
 }

--- a/backend/gateway-sv/service/src/main/resources/application-local.yml
+++ b/backend/gateway-sv/service/src/main/resources/application-local.yml
@@ -54,6 +54,12 @@ spring:
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_EXPORT_HOST}:${SERVICES_EXPORT_PORT}
               predicates:
                 - Path=/api/export/**
+            - id: messaging_v3_api_docs
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
+              predicates:
+                - Path=/api/messaging/v3/api-docs/**
+              filters:
+                - RewritePath=/api/messaging/v3/api-docs(?<segment>.*), /v3/api-docs$\{segment}
             - id: messaging
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
               predicates:
@@ -96,9 +102,11 @@ springdoc:
         url: /api/users/v3/api-docs
       - name: Export Service
         url: /api/export/v3/api-docs
+      - name: Messaging Service
+        url: /api/messaging/v3/api-docs
 r8n:
   security:
-    public-paths: /api/auth/**, /swagger-ui.html, /swagger-ui/**, /v3/api-docs/**, /api/*/v3/api-docs/**, /webjars/swagger-ui/**, /api/opinions/v3/api-docs/**, /api/users/v3/api-docs/**, /api/export/v3/api-docs/**
+    public-paths: /api/auth/**, /swagger-ui.html, /swagger-ui/**, /v3/api-docs/**, /api/*/v3/api-docs/**, /webjars/swagger-ui/**, /api/opinions/v3/api-docs/**, /api/users/v3/api-docs/**, /api/export/v3/api-docs/**, /api/messaging/v3/api-docs/**
     jwt:
       private-key: ${JWT_PRIVATE_KEY}
       public-key: ${JWT_PUBLIC_KEY}

--- a/backend/gateway-sv/service/src/main/resources/application-local.yml
+++ b/backend/gateway-sv/service/src/main/resources/application-local.yml
@@ -90,6 +90,17 @@ spring:
                     limit: 100
                     durationSeconds: 60
                 - RewritePath=/api/public/users/(?<segment>.*), /api/users/$\{segment}
+            - id: public_messaging
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
+              predicates:
+                - Path=/api/public/messaging/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/messaging/(?<segment>.*), /api/messaging/$\{segment}
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/backend/gateway-sv/service/src/main/resources/application.yml
+++ b/backend/gateway-sv/service/src/main/resources/application.yml
@@ -94,6 +94,17 @@ spring:
                     limit: 100
                     durationSeconds: 60
                 - RewritePath=/api/public/users/(?<segment>.*), /api/users/$\{segment}
+            - id: public_messaging
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
+              predicates:
+                - Path=/api/public/messaging/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/messaging/(?<segment>.*), /api/messaging/$\{segment}
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/backend/gateway-sv/service/src/main/resources/application.yml
+++ b/backend/gateway-sv/service/src/main/resources/application.yml
@@ -58,6 +58,12 @@ spring:
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_EXPORT_HOST}:${SERVICES_EXPORT_PORT}
               predicates:
                 - Path=/api/export/**
+            - id: messaging_v3_api_docs
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
+              predicates:
+                - Path=/api/messaging/v3/api-docs/**
+              filters:
+                - RewritePath=/api/messaging/v3/api-docs(?<segment>.*), /v3/api-docs$\{segment}
             - id: messaging
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MESSAGING_HOST}:${SERVICES_MESSAGING_PORT}
               predicates:
@@ -100,9 +106,11 @@ springdoc:
         url: /api/users/v3/api-docs
       - name: Export Service
         url: /api/export/v3/api-docs
+      - name: Messaging Service
+        url: /api/messaging/v3/api-docs
 r8n:
   security:
-    public-paths: /api/auth/**, /swagger-ui.html, /swagger-ui/**, /v3/api-docs/**, /api/*/v3/api-docs/**, /webjars/swagger-ui/**, /api/opinions/v3/api-docs/**, /api/users/v3/api-docs/**, /api/export/v3/api-docs/**
+    public-paths: /api/auth/**, /swagger-ui.html, /swagger-ui/**, /v3/api-docs/**, /api/*/v3/api-docs/**, /webjars/swagger-ui/**, /api/opinions/v3/api-docs/**, /api/users/v3/api-docs/**, /api/export/v3/api-docs/**, /api/messaging/v3/api-docs/**
     jwt:
       private-key: ${JWT_PRIVATE_KEY}
       public-key: ${JWT_PUBLIC_KEY}

--- a/backend/messaging-sv/api/src/main/kotlin/com/r8n/backend/messaging/api/MessagingApi.kt
+++ b/backend/messaging-sv/api/src/main/kotlin/com/r8n/backend/messaging/api/MessagingApi.kt
@@ -6,6 +6,9 @@ import com.r8n.backend.messaging.api.dto.messaging.CreateSupportMessageRequestDt
 import com.r8n.backend.messaging.api.dto.messaging.CreateSupportThreadRequestDto
 import com.r8n.backend.messaging.api.dto.messaging.SupportMessageDto
 import com.r8n.backend.messaging.api.dto.messaging.SupportThreadSummaryDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -13,6 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import java.util.UUID
 
+@Tag(name = "Support messaging", description = "Support conversations between users and the support team.")
 interface MessagingApi {
     companion object {
         private const val ROOT_PATH = "/api/messaging"
@@ -22,12 +26,20 @@ interface MessagingApi {
     }
 
     @GetMapping(SUPPORT_THREADS_PATH)
+    @Operation(
+        summary = "List support threads",
+        description = "Returns the authenticated actor's support thread summaries, ordered and paged by the service.",
+    )
     fun getSupportThreadSummaries(
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<SupportThreadSummaryDto>
 
     @PostMapping(SUPPORT_THREADS_PATH)
+    @Operation(
+        summary = "Create a support thread",
+        description = "Starts a new support thread for the authenticated user and stores the initial message.",
+    )
     fun createSupportThread(
         @Valid
         @RequestBody
@@ -35,7 +47,12 @@ interface MessagingApi {
     ): SupportThreadSummaryDto
 
     @GetMapping(SUPPORT_THREAD_MESSAGES_PATH)
+    @Operation(
+        summary = "List support thread messages",
+        description = "Returns paged messages for a support thread visible to the authenticated actor.",
+    )
     fun getSupportThreadMessages(
+        @Parameter(description = "Support thread identifier.")
         @PathVariable
         threadId: UUID,
         @Valid
@@ -43,7 +60,12 @@ interface MessagingApi {
     ): PageResponseDto<SupportMessageDto>
 
     @PostMapping(SUPPORT_THREAD_MESSAGES_PATH)
+    @Operation(
+        summary = "Add a support message",
+        description = "Adds a message to an existing support thread visible to the authenticated actor.",
+    )
     fun addSupportThreadMessage(
+        @Parameter(description = "Support thread identifier.")
         @PathVariable
         threadId: UUID,
         @Valid

--- a/backend/messaging-sv/service/src/main/resources/application-local.yml
+++ b/backend/messaging-sv/service/src/main/resources/application-local.yml
@@ -19,7 +19,10 @@ spring:
   sql:
     init:
       mode: never
+springdoc:
+  packages-to-scan: com.r8n.backend.messaging.controller, com.r8n.backend.messaging.api
 r8n:
   security:
+    public-paths: /v3/api-docs/**, /swagger-ui.html, /swagger-ui/**, /webjars/swagger-ui/**
     jwt:
       public-key: ${JWT_PUBLIC_KEY}

--- a/backend/messaging-sv/service/src/main/resources/application.yml
+++ b/backend/messaging-sv/service/src/main/resources/application.yml
@@ -26,7 +26,10 @@ spring:
   sql:
     init:
       mode: never
+springdoc:
+  packages-to-scan: com.r8n.backend.messaging.controller, com.r8n.backend.messaging.api
 r8n:
   security:
+    public-paths: /v3/api-docs/**, /swagger-ui.html, /swagger-ui/**, /webjars/swagger-ui/**
     jwt:
       public-key: ${JWT_PUBLIC_KEY}

--- a/backend/mock-sv/service/src/main/kotlin/com/r8n/backend/mock/controller/StubRecommendationController.kt
+++ b/backend/mock-sv/service/src/main/kotlin/com/r8n/backend/mock/controller/StubRecommendationController.kt
@@ -8,12 +8,14 @@ import com.r8n.backend.opinions.stub.OpinionListTestDataFactory.getListSummary
 import com.r8n.backend.opinions.stub.OpinionSubjectTestDataFactory.cappuccino2
 import com.r8n.backend.opinions.stub.OpinionSubjectTestDataFactory.cappuccino3
 import com.r8n.backend.security.Authority.IS_USER
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.domain.PageImpl
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
+@Hidden
 class StubRecommendationController : RecommendationApi {
     @PreAuthorize(IS_USER)
     override fun getRecommendedSubjects(

--- a/backend/mock-sv/service/src/main/kotlin/com/r8n/backend/mock/controller/StubSelectorController.kt
+++ b/backend/mock-sv/service/src/main/kotlin/com/r8n/backend/mock/controller/StubSelectorController.kt
@@ -6,12 +6,14 @@ import com.r8n.backend.mock.api.SelectorApi
 import com.r8n.backend.mock.api.dto.about.SelectorDto
 import com.r8n.backend.mock.stub.SelectorTestDataFactory
 import com.r8n.backend.security.Authority.IS_USER
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.domain.PageImpl
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
+@Hidden
 class StubSelectorController : SelectorApi {
     @PreAuthorize(IS_USER)
     override fun getForURL(

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/IncomingAccessRequestApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/IncomingAccessRequestApi.kt
@@ -4,6 +4,9 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.access.dto.AccessRequestDto
 import com.r8n.backend.opinions.api.access.dto.RequestStatusEnumDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -12,6 +15,10 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.time.Instant
 import java.util.UUID
 
+@Tag(
+    name = "Incoming access requests",
+    description = "Access requests received for opinion lists owned by the authenticated user.",
+)
 interface IncomingAccessRequestApi {
     companion object {
         private const val ROOT_PATH = "/api/access-requests/incoming"
@@ -22,11 +29,20 @@ interface IncomingAccessRequestApi {
     }
 
     @GetMapping(GET_PATH)
+    @Operation(
+        summary = "List incoming access requests",
+        description =
+            "Returns incoming access requests for the authenticated user's opinion lists, " +
+                "optionally filtered by list, time, or status.",
+    )
     fun get(
+        @Parameter(description = "Optional opinion list identifier to filter by.")
         @RequestParam(required = false)
         forListId: UUID?,
+        @Parameter(description = "Only include requests created or updated since this timestamp.")
         @RequestParam(required = false)
         since: Instant?,
+        @Parameter(description = "Optional request status to filter by.")
         @RequestParam(required = false)
         status: RequestStatusEnumDto?,
         @Valid
@@ -34,17 +50,32 @@ interface IncomingAccessRequestApi {
     ): PageResponseDto<AccessRequestDto>
 
     @PostMapping(ACCEPT_PATH)
+    @Operation(
+        summary = "Accept incoming access request",
+        description = "Grants access for an incoming request owned by the authenticated user.",
+    )
     fun accept(
+        @Parameter(description = "Access request identifier.")
         @PathVariable requestId: UUID,
     ): AccessRequestDto
 
     @PostMapping(DECLINE_PATH)
+    @Operation(
+        summary = "Decline incoming access request",
+        description = "Declines an incoming access request without granting access.",
+    )
     fun decline(
+        @Parameter(description = "Access request identifier.")
         @PathVariable requestId: UUID,
     ): AccessRequestDto
 
     @PostMapping(HIDE_PATH)
+    @Operation(
+        summary = "Hide incoming access request",
+        description = "Hides an incoming access request from the authenticated user's active request list.",
+    )
     fun hide(
+        @Parameter(description = "Access request identifier.")
         @PathVariable requestId: UUID,
     ): AccessRequestDto
 }

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/IncomingAccessRequestApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/IncomingAccessRequestApi.kt
@@ -72,7 +72,9 @@ interface IncomingAccessRequestApi {
     @PostMapping(HIDE_PATH)
     @Operation(
         summary = "Hide incoming access request",
-        description = "Hides an incoming access request from the authenticated user's active request list.",
+        description =
+            "Hides an incoming access request from the authenticated user's active request list. " +
+                "It keeps showing up as pending for the requestor. You can unhide, approve, or reject it later.",
     )
     fun hide(
         @Parameter(description = "Access request identifier.")

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/OutgoingAccessRequestApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/access/OutgoingAccessRequestApi.kt
@@ -4,6 +4,9 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.access.dto.AccessRequestDto
 import com.r8n.backend.opinions.api.access.dto.RequestStatusEnumDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -12,6 +15,10 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.time.Instant
 import java.util.UUID
 
+@Tag(
+    name = "Outgoing access requests",
+    description = "Access requests created by the authenticated user for other users' opinion lists.",
+)
 interface OutgoingAccessRequestApi {
     companion object {
         private const val ROOT_PATH = "/api/access-requests/outgoing"
@@ -21,11 +28,20 @@ interface OutgoingAccessRequestApi {
     }
 
     @GetMapping(GET_PATH)
+    @Operation(
+        summary = "List outgoing access requests",
+        description =
+            "Returns access requests created by the authenticated user, " +
+                "optionally filtered by list, time, or status.",
+    )
     fun get(
+        @Parameter(description = "Optional opinion list identifier to filter by.")
         @RequestParam(required = false)
         forListId: UUID?,
+        @Parameter(description = "Only include requests created or updated since this timestamp.")
         @RequestParam(required = false)
         since: Instant?,
+        @Parameter(description = "Optional request status to filter by.")
         @RequestParam(required = false)
         status: RequestStatusEnumDto?,
         @Valid
@@ -33,12 +49,22 @@ interface OutgoingAccessRequestApi {
     ): PageResponseDto<AccessRequestDto>
 
     @PostMapping(CREATE_PATH)
+    @Operation(
+        summary = "Create outgoing access request",
+        description = "Requests access to an opinion list for the authenticated user.",
+    )
     fun create(
+        @Parameter(description = "Opinion list identifier to request access to.")
         @PathVariable listId: UUID,
     ): AccessRequestDto
 
     @PostMapping(CANCEL_PATH)
+    @Operation(
+        summary = "Cancel outgoing access request",
+        description = "Cancels a pending access request created by the authenticated user.",
+    )
     fun cancel(
+        @Parameter(description = "Access request identifier.")
         @PathVariable requestId: UUID,
     ): AccessRequestDto
 }

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/lists/OpinionListsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/lists/OpinionListsApi.kt
@@ -3,6 +3,9 @@ package com.r8n.backend.opinions.api.lists
 import com.r8n.backend.opinions.api.lists.dto.OpinionListDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListPrivacyEnumDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListSummaryDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
 @Validated
+@Tag(name = "Opinion lists", description = "Opinion-list ownership, privacy, and opinion linking endpoints.")
 interface OpinionListsApi {
     companion object {
         private const val ROOT_PATH = "/api/opinion-lists"
@@ -34,30 +38,53 @@ interface OpinionListsApi {
     }
 
     @GetMapping(SUMMARY_PATH)
+    @Operation(
+        summary = "Get opinion list summary",
+        description = "Returns summary information for an opinion list visible to the authenticated user.",
+    )
     fun getListSummary(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable listId: UUID,
     ): OpinionListSummaryDto
 
     @GetMapping(GET_PATH)
+    @Operation(
+        summary = "Get opinion list",
+        description = "Returns an opinion list visible to the authenticated user.",
+    )
     fun getList(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable listId: UUID,
+        @Parameter(description = "Only include opinions published after this timestamp.")
         @RequestParam(required = false) publishedAfter: java.time.Instant?,
     ): OpinionListDto
 
     @PostMapping(CREATE_PATH)
+    @Operation(
+        summary = "Create opinion list",
+        description = "Creates an opinion list owned by the authenticated user.",
+    )
     fun createList(
+        @Parameter(description = "Opinion list name.")
         @RequestParam(required = true)
         @NotBlank
         @Size(min = 1, max = 255)
         name: String,
+        @Parameter(description = "Initial opinion list privacy setting.")
         @RequestParam(required = true)
         privacy: OpinionListPrivacyEnumDto,
     ): OpinionListDto
 
     @PatchMapping(RENAME_PATH)
+    @Operation(
+        summary = "Rename opinion list",
+        description = "Renames an opinion list owned by the authenticated user.",
+    )
     fun renameList(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable
         listId: UUID,
+        @Parameter(description = "Replacement opinion list name.")
         @RequestParam(required = true)
         @NotBlank
         @Size(min = 1, max = 255)
@@ -65,27 +92,46 @@ interface OpinionListsApi {
     ): OpinionListDto
 
     @PatchMapping(SET_PRIVACY_PATH)
+    @Operation(
+        summary = "Change opinion list privacy",
+        description = "Changes the privacy setting for an opinion list owned by the authenticated user.",
+    )
     fun changePrivacy(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable
         listId: UUID,
+        @Parameter(description = "Replacement privacy setting.")
         @RequestParam(required = true)
         privacy: OpinionListPrivacyEnumDto,
     ): OpinionListDto
 
     @DeleteMapping(DELETE_PATH)
+    @Operation(
+        summary = "Delete opinion list",
+        description = "Deletes an opinion list owned by the authenticated user.",
+    )
     fun deleteList(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable
         listId: UUID,
     )
 
     @PostMapping(MOVE_OPINION_PATH)
+    @Operation(
+        summary = "Move linked opinion",
+        description = "Moves an opinion link from one opinion list to another and sets its weight.",
+    )
     fun moveOpinion(
+        @Parameter(description = "Source opinion list identifier.")
         @PathVariable
         fromListId: UUID,
+        @Parameter(description = "Target opinion list identifier.")
         @RequestParam(required = true)
         toListId: UUID,
+        @Parameter(description = "Opinion identifier to move.")
         @RequestParam(required = true)
         opinionId: UUID,
+        @Parameter(description = "Opinion weight in the target list.")
         @RequestParam(defaultValue = "1.0")
         @Min(0)
         @Max(1)
@@ -93,11 +139,18 @@ interface OpinionListsApi {
     ): OpinionListDto
 
     @PostMapping(LINK_PATH)
+    @Operation(
+        summary = "Link opinion to list",
+        description = "Adds an opinion to an opinion list owned by the authenticated user.",
+    )
     fun linkOpinion(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable
         listId: UUID,
+        @Parameter(description = "Opinion identifier to link.")
         @RequestParam(required = true)
         opinionId: UUID,
+        @Parameter(description = "Opinion weight in the list.")
         @RequestParam(defaultValue = "1.0")
         @Min(0)
         @Max(1)
@@ -105,19 +158,32 @@ interface OpinionListsApi {
     ): OpinionListDto
 
     @PatchMapping(UNLINK_PATH)
+    @Operation(
+        summary = "Unlink opinion from list",
+        description = "Removes an opinion from an opinion list owned by the authenticated user.",
+    )
     fun unlinkOpinion(
+        @Parameter(description = "Opinion list identifier.")
         @PathVariable
         listId: UUID,
+        @Parameter(description = "Opinion identifier to unlink.")
         @RequestParam(required = true)
         opinionId: UUID,
     ): OpinionListDto
 
     @PostMapping(SYNC_PATH)
+    @Operation(
+        summary = "Sync opinion list",
+        description = "Links another opinion list as a weighted source for an existing opinion list.",
+    )
     fun syncWithOpinionList(
+        @Parameter(description = "Opinion list receiving the synced source.")
         @PathVariable
         existingListId: UUID,
+        @Parameter(description = "Opinion list to add as a synced source.")
         @RequestParam(required = true)
         addedListId: UUID,
+        @Parameter(description = "Synced list weight.")
         @RequestParam(defaultValue = "1.0")
         @Min(0)
         @Max(1)
@@ -125,9 +191,15 @@ interface OpinionListsApi {
     ): OpinionListDto
 
     @PostMapping(UNSYNC_PATH)
+    @Operation(
+        summary = "Unsync opinion list",
+        description = "Removes a synced opinion list source from an existing opinion list.",
+    )
     fun unsyncWithOpinionList(
+        @Parameter(description = "Opinion list that contains the synced source.")
         @PathVariable
         existingListId: UUID,
+        @Parameter(description = "Synced opinion list to remove.")
         @RequestParam(required = true)
         removedListId: UUID,
     ): OpinionListDto

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/lists/OpinionListsSearchApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/lists/OpinionListsSearchApi.kt
@@ -6,11 +6,17 @@ import com.r8n.backend.opinions.api.lists.dto.OpinionListNameAndOwnerDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListNameDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListSearchFiltersDto
 import com.r8n.backend.opinions.api.lists.dto.OpinionListSummaryDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
 
 @Validated
+@Tag(
+    name = "Opinion list search",
+    description = "Opinion-list discovery and authenticated user's list lookup endpoints.",
+)
 interface OpinionListsSearchApi {
     companion object {
         private const val ROOT_PATH = "/api/opinion-lists"
@@ -21,6 +27,10 @@ interface OpinionListsSearchApi {
     }
 
     @GetMapping(SEARCH_PATH)
+    @Operation(
+        summary = "Discover opinion lists",
+        description = "Searches opinion lists visible to the authenticated user with filter and paging parameters.",
+    )
     fun discover(
         @Valid
         filters: OpinionListSearchFiltersDto,
@@ -29,18 +39,30 @@ interface OpinionListsSearchApi {
     ): PageResponseDto<OpinionListSummaryDto>
 
     @GetMapping(MINE_PATH)
+    @Operation(
+        summary = "List my opinion lists",
+        description = "Returns opinion lists owned by the authenticated user.",
+    )
     fun getMine(
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<OpinionListSummaryDto>
 
     @GetMapping(APPROVED_PATH)
+    @Operation(
+        summary = "List approved opinion lists",
+        description = "Returns approved opinion lists with names and owner information.",
+    )
     fun getApprovedListsWithNamesAndOwners(
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<OpinionListNameAndOwnerDto>
 
     @GetMapping(MINE_NAMES_PATH)
+    @Operation(
+        summary = "List my opinion list names",
+        description = "Returns only names and identifiers for opinion lists owned by the authenticated user.",
+    )
     fun getMineNamesOnly(
         @Valid
         pageable: PageRequestDto,

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/opinions/OpinionsApi.kt
@@ -5,6 +5,9 @@ import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.dto.ModerationDecisionDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionDto
 import com.r8n.backend.opinions.api.opinions.dto.RejectOpinionRequestDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import java.util.UUID
 
+@Tag(name = "Opinions", description = "Opinion authoring, component linking, and moderation endpoints.")
 interface OpinionsApi {
     companion object {
         private const val ROOT_PATH = "/api/opinions"
@@ -34,67 +38,121 @@ interface OpinionsApi {
     }
 
     @GetMapping(GET_BY_ID_PATH)
+    @Operation(
+        summary = "Get opinion by id",
+        description = "Returns an opinion visible to the authenticated actor.",
+    )
     fun getOpinionById(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable id: UUID,
     ): OpinionDto
 
     @GetMapping(GET_FOR_SUBJECT_PATH)
+    @Operation(
+        summary = "Get my opinion for subject",
+        description = "Returns the authenticated user's opinion for a subject.",
+    )
     fun getOpinionFor(
+        @Parameter(description = "Subject identifier.")
         @PathVariable subjectId: UUID,
     ): OpinionDto
 
     @PostMapping(CREATE_PATH)
+    @Operation(
+        summary = "Create opinion",
+        description = "Creates an opinion for a subject with subjective text, objective text, and optional mark.",
+    )
     fun createOpinion(
+        @Parameter(description = "Subject identifier.")
         @RequestParam(required = true)
         subjectId: UUID,
+        @Parameter(description = "Subjective opinion statements.")
         @RequestParam(required = false)
         subjective: List<String>,
+        @Parameter(description = "Objective supporting statements.")
         @RequestParam(required = false)
         objective: List<String>,
+        @Parameter(description = "Optional numeric mark.")
         @RequestParam(required = false)
         mark: Double?,
     ): OpinionDto
 
     @PatchMapping(UPDATE_PATH)
+    @Operation(
+        summary = "Update opinion",
+        description = "Updates editable fields on an opinion owned by the authenticated user.",
+    )
     fun updateOpinion(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable opinionId: UUID,
+        @Parameter(description = "Replacement subjective opinion statements.")
         @RequestParam(required = false)
         subjective: List<String>,
+        @Parameter(description = "Replacement objective supporting statements.")
         @RequestParam(required = false)
         objective: List<String>,
+        @Parameter(description = "Replacement numeric mark.")
         @RequestParam(required = false)
         mark: Double?,
     ): OpinionDto
 
     @DeleteMapping(DELETE_PATH)
+    @Operation(
+        summary = "Delete opinion",
+        description = "Deletes an opinion owned by the authenticated user.",
+    )
     fun deleteOpinion(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable opinionId: UUID,
     )
 
     @PostMapping(SUBMIT_FOR_MODERATION_PATH)
+    @Operation(
+        summary = "Submit opinion for moderation",
+        description = "Moves an opinion into the moderation workflow before publication.",
+    )
     fun submitOpinionForModeration(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable opinionId: UUID,
     ): OpinionDto
 
     @GetMapping(MODERATION_PATH)
+    @Operation(
+        summary = "List opinions for moderation",
+        description = "Returns opinions waiting for moderator review.",
+    )
     fun getModerationOpinions(
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<OpinionDto>
 
     @GetMapping(MODERATION_DECISIONS_PATH)
+    @Operation(
+        summary = "List moderation decisions",
+        description = "Returns historical moderation decisions for audit and review.",
+    )
     fun getModerationDecisions(
         @Valid
         pageable: PageRequestDto,
     ): PageResponseDto<ModerationDecisionDto>
 
     @PostMapping(APPROVE_PATH)
+    @Operation(
+        summary = "Approve opinion",
+        description = "Approves an opinion in moderation and makes the decision auditable.",
+    )
     fun approveOpinion(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable opinionId: UUID,
     ): OpinionDto
 
     @PostMapping(REJECT_PATH)
+    @Operation(
+        summary = "Reject opinion",
+        description = "Rejects an opinion in moderation with a reason visible through moderation decision history.",
+    )
     fun rejectOpinion(
+        @Parameter(description = "Opinion identifier.")
         @PathVariable opinionId: UUID,
         @Valid
         @RequestBody
@@ -102,23 +160,41 @@ interface OpinionsApi {
     ): OpinionDto
 
     @PostMapping(LINK_PATH)
+    @Operation(
+        summary = "Link component opinion",
+        description = "Links a child opinion as a weighted component of a parent opinion.",
+    )
     fun linkComponent(
+        @Parameter(description = "Parent opinion identifier.")
         @RequestParam(required = true)
         parentOpinionId: UUID,
+        @Parameter(description = "Child opinion identifier.")
         @RequestParam(required = true)
         childOpinionId: UUID,
+        @Parameter(description = "Component weight.")
         @RequestParam(required = true)
         weight: Double,
     ): OpinionDto
 
     @DeleteMapping(UNLINK_PATH)
+    @Operation(
+        summary = "Unlink component opinion",
+        description = "Removes a component link from an opinion owned by the authenticated user.",
+    )
     fun unlinkComponent(
+        @Parameter(description = "Component link identifier.")
         @PathVariable linkId: UUID,
     ): OpinionDto
 
     @PatchMapping(ADJUST_WEIGHT_PATH)
+    @Operation(
+        summary = "Adjust component weight",
+        description = "Changes the weight assigned to an existing component opinion link.",
+    )
     fun adjustComponentWeight(
+        @Parameter(description = "Component link identifier.")
         @PathVariable linkId: UUID,
+        @Parameter(description = "Replacement component weight.")
         @RequestParam(required = true)
         weight: Double,
     ): OpinionDto

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/subjects/SubjectsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/subjects/SubjectsApi.kt
@@ -51,8 +51,14 @@ interface SubjectsApi {
     ): OpinionSubjectDto
 
     @PatchMapping(SET_PRIMARY_REFERENT_PATH)
+    @Operation(
+        summary = "Set primary referent",
+        description = "Sets the primary referent used to identify or disambiguate a subject.",
+    )
     fun setPrimaryReferent(
+        @Parameter(description = "Subject identifier.")
         @PathVariable subjectId: UUID,
+        @Parameter(description = "Referent identifier to make primary.")
         @RequestParam(required = true) referentId: UUID,
     ): OpinionSubjectDto
 }

--- a/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/subjects/SubjectsApi.kt
+++ b/backend/opinions-sv/api/src/main/kotlin/com/r8n/backend/opinions/api/subjects/SubjectsApi.kt
@@ -4,6 +4,9 @@ import com.r8n.backend.core.api.PageRequestDto
 import com.r8n.backend.core.api.PageResponseDto
 import com.r8n.backend.opinions.api.opinions.dto.OpinionSubjectDto
 import com.r8n.backend.opinions.api.subjects.dto.CreateSubjectRequestDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import org.springframework.web.bind.annotation.GetMapping
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 
+@Tag(name = "Subjects", description = "Reviewable subjects that opinions can be written about.")
 interface SubjectsApi {
     companion object {
         private const val ROOT_PATH = "/api/subjects"
@@ -19,7 +23,12 @@ interface SubjectsApi {
     }
 
     @GetMapping(FIND_PATH)
+    @Operation(
+        summary = "Find subjects",
+        description = "Searches reviewable subjects by text and returns paged matches.",
+    )
     fun findSubject(
+        @Parameter(description = "Text to search for in subject data.")
         @RequestParam(required = true)
         @NotBlank
         query: String,
@@ -28,6 +37,10 @@ interface SubjectsApi {
     ): PageResponseDto<OpinionSubjectDto>
 
     @PostMapping(CREATE_PATH)
+    @Operation(
+        summary = "Create subject",
+        description = "Creates a reviewable subject when it does not already exist.",
+    )
     fun createSubject(
         @Valid
         @RequestBody

--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/lists/controller/StubOpinionListController.kt
@@ -11,12 +11,14 @@ import com.r8n.backend.opinions.lists.facade.OpinionListFacade
 import com.r8n.backend.opinions.stub.OpinionListTestDataFactory
 import com.r8n.backend.security.Authority.IS_USER
 import com.r8n.backend.security.CurrentUserIdentifier.getCurrentUserId
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.domain.PageImpl
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
+@Hidden
 class StubOpinionListController(
     private val opinionListFacade: OpinionListFacade,
     private val accessRequestRepository: AccessRequestRepository,

--- a/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
+++ b/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
@@ -54,7 +54,9 @@ interface AuthApi {
     @PostMapping(LOGOUT_PATH)
     @Operation(
         summary = "Log out",
-        description = "Invalidates the refresh token when present and clears the refresh token cookie.",
+        description =
+            "Ends the user's session. " +
+                "Invalidates the refresh token when present and clears the refresh token cookie.",
     )
     fun logout(
         @Parameter(description = "Refresh token cookie issued by login or refresh.")

--- a/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
+++ b/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/AuthApi.kt
@@ -3,6 +3,9 @@ package com.r8n.backend.users.api
 import com.r8n.backend.users.api.dto.AuthenticationTokenDto
 import com.r8n.backend.users.api.dto.LoginRequestDto
 import com.r8n.backend.users.api.dto.RegisterRequestDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.ResponseStatus
 
+@Tag(name = "Authentication", description = "Registration, login, logout, refresh-token, and CSRF endpoints.")
 interface AuthApi {
     companion object {
         const val REFRESH_TOKEN_COOKIE_NAME = "refreshToken"
@@ -22,26 +26,48 @@ interface AuthApi {
     }
 
     @GetMapping(CSRF_PATH)
+    @Operation(
+        summary = "Create CSRF cookie",
+        description = "Issues a non-HTTP-only XSRF-TOKEN cookie for browser clients before state-changing requests.",
+    )
     fun csrf()
 
     @PostMapping(LOGIN_PATH)
+    @Operation(
+        summary = "Log in",
+        description = "Authenticates a user, returns an access token, and sets the refresh token cookie.",
+    )
     fun login(
         @RequestBody request: LoginRequestDto,
     ): AuthenticationTokenDto
 
     @PostMapping(REGISTER_PATH)
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "Register account",
+        description = "Creates a new user account and records minimal registration audit context.",
+    )
     fun register(
         @RequestBody request: RegisterRequestDto,
     )
 
     @PostMapping(LOGOUT_PATH)
+    @Operation(
+        summary = "Log out",
+        description = "Invalidates the refresh token when present and clears the refresh token cookie.",
+    )
     fun logout(
+        @Parameter(description = "Refresh token cookie issued by login or refresh.")
         @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) refreshToken: String?,
     )
 
     @PostMapping(REFRESH_PATH)
+    @Operation(
+        summary = "Refresh access token",
+        description = "Rotates the refresh token cookie and returns a new short-lived access token.",
+    )
     fun refresh(
+        @Parameter(description = "Refresh token cookie issued by login or a previous refresh.")
         @CookieValue(name = REFRESH_TOKEN_COOKIE_NAME, required = false) refreshToken: String?,
     ): AuthenticationTokenDto
 }

--- a/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/UsersApi.kt
+++ b/backend/users-sv/api/src/main/kotlin/com/r8n/backend/users/api/UsersApi.kt
@@ -5,6 +5,9 @@ import com.r8n.backend.users.api.dto.UpdateMyPublicProfileRequestDto
 import com.r8n.backend.users.api.dto.UserProfileDto
 import com.r8n.backend.users.api.dto.UserWithRolesDto
 import com.r8n.backend.users.api.dto.UsernameDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.multipart.MultipartFile
 import java.util.UUID
 
+@Tag(name = "Users", description = "User profile, avatar, and administrative role management endpoints.")
 interface UsersApi {
     companion object {
         private const val ROOT_PATH = "/api/users"
@@ -32,22 +36,40 @@ interface UsersApi {
     }
 
     @GetMapping(ME_PATH)
+    @Operation(
+        summary = "Get my username",
+        description = "Returns the display username for the authenticated user.",
+    )
     fun getMyName(): UsernameDto
 
     @GetMapping(USER_PATH)
+    @Operation(
+        summary = "Get public user profile",
+        description = "Returns the public profile fields for a user.",
+    )
     fun getUserProfile(
+        @Parameter(description = "Public user identifier.")
         @PathVariable
         id: UUID,
     ): UserProfileDto
 
     @PatchMapping(MY_PUBLIC_PROFILE_PATH)
+    @Operation(
+        summary = "Update my public profile",
+        description = "Updates public profile fields for the authenticated user.",
+    )
     fun updateMyPublicProfile(
         @RequestBody
         request: UpdateMyPublicProfileRequestDto,
     ): UserProfileDto
 
     @GetMapping(USER_AVATAR_PATH)
+    @Operation(
+        summary = "Get user avatar",
+        description = "Returns a user's avatar bytes when one is available.",
+    )
     fun getUserAvatar(
+        @Parameter(description = "Public user identifier.")
         @PathVariable
         id: UUID,
     ): ResponseEntity<ByteArray>
@@ -56,26 +78,50 @@ interface UsersApi {
         MY_AVATAR_PATH,
         consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
     )
+    @Operation(
+        summary = "Upload my avatar",
+        description = "Stores or replaces the authenticated user's avatar image.",
+    )
     fun uploadMyAvatar(
+        @Parameter(description = "Avatar image file.")
         @RequestPart("file")
         file: MultipartFile,
     ): ResponseEntity<Void>
 
     @DeleteMapping(MY_AVATAR_PATH)
+    @Operation(
+        summary = "Delete my avatar",
+        description = "Removes the authenticated user's stored avatar image.",
+    )
     fun deleteMyAvatar(): ResponseEntity<Void>
 
     @GetMapping(ADMIN_USERS_PATH)
+    @Operation(
+        summary = "List users with roles",
+        description = "Returns users and their assigned roles for administrative review.",
+    )
     fun listUsersWithRoles(): List<UserWithRolesDto>
 
     @PostMapping(ADMIN_USER_ROLES_PATH)
+    @Operation(
+        summary = "Assign user role",
+        description = "Assigns a role to a user. Requires an authenticated administrator.",
+    )
     fun assignRole(
+        @Parameter(description = "User identifier receiving the role.")
         @PathVariable userId: UUID,
         @RequestBody request: AssignRoleRequestDto,
     ): ResponseEntity<Void>
 
     @DeleteMapping(ADMIN_USER_ROLE_PATH)
+    @Operation(
+        summary = "Revoke user role",
+        description = "Removes a role from a user. Requires an authenticated administrator.",
+    )
     fun revokeRole(
+        @Parameter(description = "User identifier losing the role.")
         @PathVariable userId: UUID,
+        @Parameter(description = "Role name to revoke.")
         @PathVariable role: String,
     ): ResponseEntity<Void>
 }


### PR DESCRIPTION
Target Changes:
- Added documentation for the current public API (services export, messaging, opinions, users)

Verification:
- Visit `https://localhost:8080/swagger-ui.html`
- On the right side you can choose a service and navigate through the docs for this service

Example:

<img width="1916" height="648" alt="image" src="https://github.com/user-attachments/assets/8022c870-3ffb-4c10-9ae7-d218b0a6eae9" />

