### PR TITLE
238 expose subjects public api

### DIFF
--- a/backend/gateway-sv/service/src/main/resources/application-local.yml
+++ b/backend/gateway-sv/service/src/main/resources/application-local.yml
@@ -79,6 +79,17 @@ spring:
                     limit: 100
                     durationSeconds: 60
                 - RewritePath=/api/public/opinions/(?<segment>.*), /api/opinions/$\{segment}
+            - id: public_subjects
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_OPINIONS_HOST}:${SERVICES_OPINIONS_PORT}
+              predicates:
+                - Path=/api/public/subjects,/api/public/subjects/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/subjects/?(?<segment>.*), /api/subjects/$\{segment}
             - id: public_users
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_USERS_HOST}:${SERVICES_USERS_PORT}
               predicates:

--- a/backend/gateway-sv/service/src/main/resources/application.yml
+++ b/backend/gateway-sv/service/src/main/resources/application.yml
@@ -83,6 +83,17 @@ spring:
                     limit: 100
                     durationSeconds: 60
                 - RewritePath=/api/public/opinions/(?<segment>.*), /api/opinions/$\{segment}
+            - id: public_subjects
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_OPINIONS_HOST}:${SERVICES_OPINIONS_PORT}
+              predicates:
+                - Path=/api/public/subjects,/api/public/subjects/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/subjects/?(?<segment>.*), /api/subjects/$\{segment}
             - id: public_users
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_USERS_HOST}:${SERVICES_USERS_PORT}
               predicates:

--- a/backend/gateway-sv/service/src/test/kotlin/com/r8n/backend/gateway/GatewayPublicRouteConfigurationTest.kt
+++ b/backend/gateway-sv/service/src/test/kotlin/com/r8n/backend/gateway/GatewayPublicRouteConfigurationTest.kt
@@ -1,0 +1,31 @@
+package com.r8n.backend.gateway
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class GatewayPublicRouteConfigurationTest {
+    @Test
+    fun `public subjects route is exposed with api key protection in every gateway config`() {
+        val gatewayConfigs =
+            listOf(
+                Path.of("src/main/resources/application.yml"),
+                Path.of("src/main/resources/application-local.yml"),
+                Path.of("src/test/resources/application-test.yml"),
+                Path.of("src/test/resources/application-test-e2e.yml"),
+            )
+
+        gatewayConfigs.forEach { config ->
+            val content = Files.readString(config)
+
+            assertThat(content)
+                .describedAs("$config exposes subjects through the public API namespace")
+                .contains("id: public_subjects")
+                .contains("Path=/api/public/subjects,/api/public/subjects/**")
+                .contains("ApiKeyAuthenticationFilter")
+                .contains("RateLimitingFilter")
+                .contains("RewritePath=/api/public/subjects/?(?<segment>.*), /api/subjects/$\\{segment}")
+        }
+    }
+}

--- a/backend/gateway-sv/service/src/test/resources/application-test-e2e.yml
+++ b/backend/gateway-sv/service/src/test/resources/application-test-e2e.yml
@@ -41,6 +41,17 @@ spring:
               uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_MOCK_HOST}:${SERVICES_MOCK_PORT}
               predicates:
                 - Path=/api/selectors/**
+            - id: public_subjects
+              uri: ${INTERSERVICE_PROTOCOL}://${SERVICES_OPINIONS_HOST}:${SERVICES_OPINIONS_PORT}
+              predicates:
+                - Path=/api/public/subjects,/api/public/subjects/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/subjects/?(?<segment>.*), /api/subjects/$\{segment}
 r8n:
   security:
     public-paths: /api/auth/**

--- a/backend/gateway-sv/service/src/test/resources/application-test.yml
+++ b/backend/gateway-sv/service/src/test/resources/application-test.yml
@@ -39,6 +39,17 @@ spring:
               uri: http://localhost:8090
               predicates:
                 - Path=/api/selectors/**
+            - id: public_subjects
+              uri: http://localhost:8081
+              predicates:
+                - Path=/api/public/subjects,/api/public/subjects/**
+              filters:
+                - ApiKeyAuthenticationFilter
+                - name: RateLimitingFilter
+                  args:
+                    limit: 100
+                    durationSeconds: 60
+                - RewritePath=/api/public/subjects/?(?<segment>.*), /api/subjects/$\{segment}
 r8n:
   security:
     public-paths: /api/auth/**


### PR DESCRIPTION

**Target Changes**
- Added a new `public_subjects` gateway route for the subjects API.
- Exposes subjects through the public API namespace:
  - `/api/public/subjects`
  - `/api/public/subjects/**`
- Rewrites public requests to the existing opinions service subjects API:
  - `/api/public/subjects` -> `/api/subjects`
  - `/api/public/subjects/**` -> `/api/subjects/**`
- Applies the same public API protections used by existing public routes:
  - `ApiKeyAuthenticationFilter`
  - `RateLimitingFilter` with `100` requests per `60` seconds
- Updated production, local, and test gateway configs to keep environments aligned.
- Added a regression test to ensure the public subjects route remains configured with API key auth, rate limiting, and the correct rewrite rule.

**Verification**
- `make docker-up`
- `make test-backend`