### PR TITLE
138 resend access after rejection

### DIFF
--- a/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/access/service/AccessRequestService.kt
+++ b/backend/opinions-sv/service/src/main/kotlin/com/r8n/backend/opinions/access/service/AccessRequestService.kt
@@ -18,6 +18,15 @@ class AccessRequestService(
     private val repository: AccessRequestRepository,
     private val accessService: AccessService,
 ) {
+    private companion object {
+        val ACTIVE_REQUEST_STATUSES =
+            listOf(
+                RequestStatusEnum.SENT,
+                RequestStatusEnum.HIDDEN,
+                RequestStatusEnum.ACCEPTED,
+            )
+    }
+
     fun getRequests(
         listId: UUID?,
         requesterId: UUID?,
@@ -59,7 +68,11 @@ class AccessRequestService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Owner cannot request access to their own list")
         }
 
-        val existing = getRequests(listId, requesterId, null, null, null, Pageable.unpaged()).firstOrNull()
+        val existing =
+            repository
+                .findByRequesterAndListAndStatusIn(requesterId, listId, ACTIVE_REQUEST_STATUSES)
+                .firstOrNull()
+                ?.toDomain()
         if (existing != null) {
             return existing
         }

--- a/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/access/AccessRequestIntegrationTest.kt
+++ b/backend/opinions-sv/service/src/test/kotlin/com/r8n/backend/opinions/access/AccessRequestIntegrationTest.kt
@@ -23,6 +23,7 @@ import com.r8n.backend.opinions.opinions.persistence.ReferentPersistence
 import com.r8n.backend.security.ServiceTokenService
 import com.r8n.backend.users.integration.api.UsersInternalApi
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -214,6 +215,19 @@ class AccessRequestIntegrationTest {
         val request: AccessRequestDto = objectMapper.readValue(createResult.response.contentAsString)
         val requestId = request.id
 
+        // Step 2b: Sending again while the request is active returns the existing request
+        val duplicateCreateResult =
+            mockMvc
+                .perform(
+                    post("/api/access-requests/outgoing/create/$listId")
+                        .header("Authorization", "Bearer $requesterToken")
+                        .with(csrf()),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val duplicateRequest: AccessRequestDto = objectMapper.readValue(duplicateCreateResult.response.contentAsString)
+        assertEquals(requestId, duplicateRequest.id)
+
         // Step 3: Requester tries to access the opinion again and fails (still 403 Forbidden)
         mockMvc
             .perform(
@@ -293,5 +307,19 @@ class AccessRequestIntegrationTest {
                     .header("Authorization", "Bearer $requesterToken")
                     .with(csrf()),
             ).andExpect(status().isForbidden)
+
+        // Step 10: Requester can send a fresh request after rejection
+        val resendResult =
+            mockMvc
+                .perform(
+                    post("/api/access-requests/outgoing/create/$listId")
+                        .header("Authorization", "Bearer $requesterToken")
+                        .with(csrf()),
+                ).andExpect(status().isOk)
+                .andReturn()
+
+        val resentRequest: AccessRequestDto = objectMapper.readValue(resendResult.response.contentAsString)
+        assertNotEquals(requestId, resentRequest.id)
+        assertEquals(RequestStatusEnumDto.SENT, resentRequest.status)
     }
 }


### PR DESCRIPTION
Target changes:

Allows users to resend an access request after a previous one was rejected or cancelled. Active requests (SENT, HIDDEN, ACCEPTED) still remain idempotent and return the existing request instead of creating duplicates.

Added integration coverage for:

- duplicate active request creation
- creating a fresh request after rejection

Verification:

- `make test-backend`